### PR TITLE
Customized pyqtgraph exports

### DIFF
--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -41,13 +41,16 @@ class FileExport:
 
     @classmethod
     def get_save_path(cls)-> None|Path:
-        """Get a file path for saving a file."""
+        """Get a file path for saving a file.
+        
+        If no extension is specified, defaults to ".txt".
+        """
         filename,_ = QFileDialog.getSaveFileName(
             caption="Save File", 
-            filter="""Text file (tab-separated)(*.txt);;
-            Text file (comma-separated)(*.csv);;
-            Microsoft Excel (*.xlsx);;Apache Parquet (*.par)
-            """, 
+            filter=(
+                "Text file (tab- or comma-separated)(*.txt *.csv);;"
+                "Microsoft Excel (*.xlsx);;Apache Parquet (*.par)"
+            ), 
             directory=cls.lastFolder
         )
         if filename=="":
@@ -102,14 +105,10 @@ class FileExport:
                     cols.iloc[(0, idx)] = "# " + cols.iloc[(0, idx)] # comment symbol to header lines
 
                 data.columns = pd.MultiIndex.from_frame(cols)
-
-            if path.suffix.lower()==".csv":
-                path.write_text(header,encoding='utf-8')
-                data.to_csv(path,sep=",", decimal=".", encoding="utf-8", mode="a", index=False)
-            
-            else: # e.g. .txt
-                path.write_text(header,encoding='utf-8')
-                data.to_csv(path,sep='\t', decimal=".", encoding="utf-8", mode="a", index=False)
+    
+            data_fmt = {"sep":",","decimal":"."} if path.suffix.lower()==".csv" else {"sep":"\t","decimal":"."} 
+            path.write_text(header,encoding="utf-8")
+            data.to_csv(path,**data_fmt, encoding="utf-8", mode="a", index=False)
 
         except Exception as e:
             QMessageBox.warning(

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -227,6 +227,7 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
     These parameters populate the export UI dialog with options to tweak the style used by matplotlib.
     """
     _selected_styles = []
+    _state = None
     def __init__(self,**opts):
         super().__init__(name="Export options",**opts)
         self.addChildren(
@@ -249,6 +250,9 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
                 }
             ]
         )
+        if self.__class__._state is not None:
+            self.restoreState(self._state)
+        self.sigTreeStateChanged.connect(lambda _: setattr(self.__class__, "_state", self.saveState()))
         for child in self.child("Matplotlib styles").children():
             child.sigValueChanged.connect(self.toggle_active_style)
 
@@ -334,8 +338,6 @@ class OESMatplotlibExporter(MatplotlibExporter):
             "mec":markeredgecolor,
             "mfc": markerfacecolor,
             "ms":markersize}
-
-
     
     def parameters(self)->PlotStyleParameters:
         return self.params
@@ -432,6 +434,7 @@ class OESDataExporter(Exporter):
     In case of using a `Plot data` export, the resulting file can be read/plotted again with the OES-toolbox as a set of spectra.
     """
     Name = "Export data (OES-toolbox)"
+    _state = None
     
     def __init__(self,item:PlotItem|GraphicsScene):
         super().__init__(item)
@@ -439,6 +442,11 @@ class OESDataExporter(Exporter):
             {"name":"Export data","type":"list","limits":["Plot data","NIST table","Molecule fit results","Continuum results"]},
         ])
         self.main_window = item.getViewWidget().window()
+        if self.__class__._state is not None:
+            self.params.restoreState(self.__class__._state)
+
+        
+        self.params.child("Export data").sigValueChanged.connect(lambda _:setattr(self.__class__,"_state",self.params.saveState()))
 
 
     def export(self):

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -93,23 +93,18 @@ class FileExport:
                         sheet.set_column_pixels(0, 0, 170)
                     return
             header = (
-                f"## OES toolbox ({version}) result file: {data.attrs['Result file']} \n"
+                f"## OES toolbox ({version}) result file: {data.attrs['Result file']}\n"
                 f"# Exported on {data.attrs['Exported on']}\n"
             )
             if isinstance(data.columns, pd.MultiIndex):
                 # use a space (`\s`) instead of empty string for text export to avoid `Unnamed columns`
                 cols = data.columns.to_frame()
-                cols = cols[cols.columns.drop("region")] # not used?!
-                for idx, col in enumerate(cols.columns):                        
+                for col in cols.columns:
                     cols[col] = cols[col].replace(""," ")
-                    cols.iloc[(0, idx)] = "# " + cols.iloc[(0, idx)] # comment symbol to header lines
-
                 data.columns = pd.MultiIndex.from_frame(cols)
-    
             data_fmt = {"sep":",","decimal":"."} if path.suffix.lower()==".csv" else {"sep":"\t","decimal":"."} 
-            path.write_text(header,encoding="utf-8")
-            data.to_csv(path,**data_fmt, encoding="utf-8", mode="a", index=False)
-
+            path.write_text(header,encoding='utf-8')
+            data.to_csv(path,**data_fmt, encoding="utf-8", mode="a", index=isinstance(data.columns, pd.MultiIndex))
         except Exception as e:
             QMessageBox.warning(
                 None,

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -220,7 +220,7 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
     
     These parameters populate the export UI dialog with options to tweak the style used by matplotlib.
     """
-    _selected_styles = []
+    _selected_styles = [TOOLBOXSTYLE]
     _state = None
     def __init__(self,**opts):
         super().__init__(name="Export options",**opts)

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -40,24 +40,36 @@ class FileExport:
     lastFolder = None
 
     @classmethod
-    def get_save_path(cls)-> None|Path:
+    def get_save_path(cls, caption=None)-> tuple[Path,dict[str,str]]|tuple[None,None]:
         """Get a file path for saving a file.
         
         If no extension is specified, defaults to ".txt".
+
+        Returns a tuple of (`filename`,`txt_fmt`), where `filename` specifies the target file path.
+        
+        The `txt_fmt` is a dict that specifies the separator and delimiter to use for text files.
+        
+        I.e. tab vs comma separated, both with decimal point.)
+
+
+        When the user cancels the dialog, returns (None,None).
         """
-        filename,_ = QFileDialog.getSaveFileName(
-            caption="Save File", 
+        filename,filter = QFileDialog.getSaveFileName(
+            parent=None,
+            caption="Save File" if caption is None else caption, 
             filter=(
-                "Text file (tab- or comma-separated)(*.txt *.csv);;"
+                "Text file (tab-separated)(*.txt *.*);;"
+                "Text file (comma-separated)(*.csv *.*);;"
                 "Microsoft Excel (*.xlsx);;Apache Parquet (*.par)"
             ), 
             directory=cls.lastFolder
         )
         if filename=="":
-            return
+            return None, None # Handle cancelation without throwing exceptions
+        txt_fmt = {"sep": "," if "comma" in filter else "\t", "decimal":"."}
         filename = Path(filename)
-        cls.lastFolder = filename.parent.as_posix()
-        return filename 
+        cls.lastFolder: str = filename.parent.as_posix()
+        return filename, txt_fmt
 
     @staticmethod
     def add_attrs(df:pd.DataFrame, kind:str):
@@ -68,7 +80,13 @@ class FileExport:
         }
     
     @classmethod
-    def store_dataframe(cls,path:Path,data:pd.DataFrame):
+    def store_dataframe(cls,path:Path,data:pd.DataFrame, txt_fmt:dict|None=None):
+        """Store the provided dataframe to the specified location, deciding the file type from the extension.
+        
+        The optional kwarg `txt_fmt` is used to control the how data is saved to a text file.
+        
+        If `txt_fmt=None` is provided, falls back to: `{"sep":"\t","decimal":"."}`
+        """
         try:
             if path.suffix.lower()==".par":
                 data.to_parquet(path)
@@ -96,15 +114,10 @@ class FileExport:
                 f"## OES toolbox ({version}) result file: {data.attrs['Result file']}\n"
                 f"# Exported on {data.attrs['Exported on']}\n"
             )
-            if isinstance(data.columns, pd.MultiIndex):
-                # use a space (`\s`) instead of empty string for text export to avoid `Unnamed columns`
-                cols = data.columns.to_frame()
-                for col in cols.columns:
-                    cols[col] = cols[col].replace(""," ")
-                data.columns = pd.MultiIndex.from_frame(cols)
-            data_fmt = {"sep":",","decimal":"."} if path.suffix.lower()==".csv" else {"sep":"\t","decimal":"."} 
+            txt_fmt = {"sep":"\t","decimal":"."} if txt_fmt is None else txt_fmt
             path.write_text(header,encoding='utf-8')
-            data.to_csv(path,**data_fmt, encoding="utf-8", mode="a", index=isinstance(data.columns, pd.MultiIndex))
+            # If columns are MultiIndex, we are dealing with a "Save" operation, else an "Export" to text.
+            data.to_csv(path,**txt_fmt, encoding="utf-8", mode="a", index=isinstance(data.columns, pd.MultiIndex))
         except Exception as e:
             QMessageBox.warning(
                 None,
@@ -169,34 +182,59 @@ class FileExport:
         return img
     
     @classmethod
-    def save_plot_data(cls, plot,kind:str="plot export"):
-        filename = cls.get_save_path()
+    def save_plot_data(cls, plot,kind:str="plot export", export=True):
+        """"Save or export the plotted data.
+        
+        In case `export = True` the operation is considered an "Export".
+        
+        For an "Export" to a text file (e.g. tsv, csv), we make no guarantee that it can be read again by OESToolbox.
+
+        This is because the MultiIndex is flattened, for easier handling of the export in external programs (Origin, Excel, Matlab).
+
+        If the features from the pandas MultiIndex need to be preserved in a text file, the `export` arg must be set to False.
+
+        In the case that `export = False` the operation is considered a "Save", and the resulting file MUST be readable by OESToolbox again.
+        
+        It may however not result in  exactly the same tree structure (mainly for files with multiple ROIs).
+
+        For other supported format, there is no different behaviour between "Exports" (export=True), or "Saves" (export=False).
+        """
+        filename,txt_fmt = cls.get_save_path(f"{'Export' if export else 'Save'} plotted data")
         if filename is None:
             return
         xlabel = plot.getAxis("bottom").label.toPlainText().strip()
         ylabel = plot.getAxis("left").label.toPlainText().strip()
         data = []
+        # export without MultiIndex for simple use in external programs (Origin, Excel, etc.)
+        flatten = export and filename.suffix.lower() in ['.txt',".csv"]
         for plot_item in plot.listDataItems():
             x,y = plot_item.getData()
-            part_names = [part.strip() for part in plot_item.name().split(": ")]
+            plot_name = plot_item.name()
+            if flatten:
+                data.append(pd.DataFrame({f"{plot_name}: {label}".strip():values for label,values in zip([xlabel,ylabel],[x,y])}))
+                continue
+            part_names = [part.strip() for part in plot_name.split(": ")]
             match len(part_names):
+                # Using " " (note the \s) is needed for preserving MultiIndex in text files, without adding many 'Unnamed...' columns
+                # By doing this generically, a test of `pandas.testing.assert_frame_equal(df_text, df_parquet)` passes.
+                # Else it fails on the index, while a `numpy.testing.assert_allclose` passes.). 
                 case 2:
-                    # Edge case: must set a 'spectrum name' to be able to reliably open the file again using pandas MultiIndex.
-                    part_names.extend(["", "spectrum 0"])
+                    part_names.extend([" "]*2)
                 case 3:
-                    part_names.insert(2, "")
+                    part_names.insert(2, " ")
             data.append(pd.DataFrame({(*part_names,label):values for label, values in zip([xlabel,ylabel],[x,y])}))
         
         df = pd.concat(data,axis=1)
-        df.columns.set_names(("type","path","region","label","axis"), inplace=True)
+        if not flatten:
+            df.columns.set_names(("type","path","region","label","axis"), inplace=True)
         cls.add_attrs(df, kind)
-        cls.store_dataframe(filename,df)
+        cls.store_dataframe(filename,df, txt_fmt = txt_fmt)
 
 
     @classmethod
     def save_table(cls,table:"QTableWidget"):
         action_name = table.sender().text()
-        filename = cls.get_save_path()
+        filename, txt_fmt = cls.get_save_path(caption=f"Export {action_name}")
         if filename is None:
             return
         if "NIST" in action_name:
@@ -212,7 +250,7 @@ class FileExport:
         df = pd.DataFrame(data)
         df = df.convert_dtypes()
         cls.add_attrs(df, kind=kind)
-        cls.store_dataframe(filename, df)
+        cls.store_dataframe(filename, df, txt_fmt=txt_fmt)
 
 
 class PlotStyleParameters(parameterTypes.GroupParameter):
@@ -432,23 +470,33 @@ class OESDataExporter(Exporter):
     
     def __init__(self,item:PlotItem|GraphicsScene):
         super().__init__(item)
-        self.params = Parameter.create(name='params', type='group', children=[
+        self.params = Parameter.create(name='File export/save options', type='group', children=[
             {"name":"Export data","type":"list","limits":["Plot data","NIST table","Molecule fit results","Continuum results"]},
+            {"name": "Save","type":"bool","value":True,"title":"Save (preserve read support)"}
         ])
         self.main_window = item.getViewWidget().window()
         if self.__class__._state is not None:
             self.params.restoreState(self.__class__._state)
 
+        for child in self.params:
+            child.sigValueChanged.connect(lambda _:setattr(self.__class__,"_state",self.params.saveState()))
+        self.params.child("Export data").sigValueChanged.connect(lambda x: self.params.child("Save").setValue(x.value()=="Plot data"))
+        self.params.child("Export data").sigValueChanged.connect(lambda x: self.params.child("Save").setWritable(x.value()=="Plot data"))
         
-        self.params.child("Export data").sigValueChanged.connect(lambda _:setattr(self.__class__,"_state",self.params.saveState()))
 
 
     def export(self):
         """Export requested data by calling the appropriate export action on the toolbox main window."""
         kind = self.params.child("Export data").value()
+        is_save = self.params.child("Save").value()
         match kind:
             case "Plot data":
-                self.main_window.action_export_plot_data.trigger()
+                if is_save:
+                    # For a text file: the file should be readable/importable again
+                    self.main_window.action_save_data.trigger()
+                else:
+                    # For a text file: file may not be opened again
+                    self.main_window.action_export_plot_data.trigger()
             case _s if "NIST" in _s:
                 self.main_window.action_export_ident_table.trigger()
             case _s if "Molecule" in _s:

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -25,6 +25,7 @@ from pyqtgraph import PlotItem
 
 from OES_toolbox.lazy_import import lazy_import
 from OES_toolbox._version import version
+from OES_toolbox.file_handling import COLUMN_LEVEL_NAMES
 pd = lazy_import("pandas")
 
 TOOLBOXSTYLE = "OES_toolbox.ui.jh-paper"
@@ -209,6 +210,7 @@ class FileExport:
         # export without MultiIndex for simple use in external programs (Origin, Excel, etc.)
         flatten = export and filename.suffix.lower() in ['.txt',".csv"]
         for plot_item in plot.listDataItems():
+            # TODO: consider exporting data from tree-item associated with a plot; may make constructing a name or multiindex simpler.
             x,y = plot_item.getData()
             plot_name = plot_item.name()
             if flatten:
@@ -216,18 +218,25 @@ class FileExport:
                 continue
             part_names = [part.strip() for part in plot_name.split(": ")]
             match len(part_names):
+                case n if n<2:
+                    raise ValueError(f"Case not supported: {len(part_names)=}<2: {part_names}")
                 # Using " " (note the \s) is needed for preserving MultiIndex in text files, without adding many 'Unnamed...' columns
                 # By doing this generically, a test of `pandas.testing.assert_frame_equal(df_text, df_parquet)` passes.
                 # Else it fails on the index, while a `numpy.testing.assert_allclose` passes.). 
                 case 2:
-                    part_names.extend([" "]*2)
+                    part_names.extend([" "] * 2)
                 case 3:
                     part_names.insert(2, " ")
+                case 4:
+                    pass
+                case _:
+                    # Perhaps could be made more fancy than taking the last 4 elements; figuring this out may be easier with the tree item instead of the plot.
+                    part_names=part_names[-4:]
             data.append(pd.DataFrame({(*part_names,label):values for label, values in zip([xlabel,ylabel],[x,y])}))
         
         df = pd.concat(data,axis=1)
         if not flatten:
-            df.columns.set_names(("type","path","region","label","axis"), inplace=True)
+            df.columns.set_names(COLUMN_LEVEL_NAMES, inplace=True)
         cls.add_attrs(df, kind)
         cls.store_dataframe(filename,df, txt_fmt = txt_fmt)
 

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -17,6 +17,12 @@ from PyQt6.QtGui import QImage, QPixmap
 from PyQt6.QtCore import Qt
 import pyqtgraph as pg
 
+from pyqtgraph import GraphicsScene
+from pyqtgraph.exporters.Matplotlib import MatplotlibExporter, MatplotlibWindow, _symbol_pg_to_mpl
+from pyqtgraph.exporters import Exporter, SVGExporter, ImageExporter
+from pyqtgraph.parametertree import Parameter,parameterTypes
+from pyqtgraph import PlotItem
+
 from OES_toolbox.lazy_import import lazy_import
 from OES_toolbox._version import version
 pd = lazy_import("pandas")
@@ -202,3 +208,239 @@ class FileExport:
         cls.store_dataframe(filename, df)
 
 
+class PlotStyleParameters(parameterTypes.GroupParameter):
+    """Parameters for the customized Matplotlib Exporter.
+    
+    These parameters populate the export UI dialog with options to tweak the style used by matplotlib.
+    """
+    _selected_styles = []
+    def __init__(self,**opts):
+        styles = style.available
+        if 'default' not in styles:
+            styles.insert(0,"default")
+        styles = [s for s in styles if not s.startswith("_")]
+        if TOOLBOXSTYLE not in styles:
+            styles.insert(1,TOOLBOXSTYLE)
+        super().__init__(name="Export options",**opts)
+        self.addChildren(
+            [
+                {"name":"dpi","value":144,"type":"int","bounds":(30,2400)},
+                {"name":"layout engine","type":"list","limits":["constrained","tight","from style"]},
+                {"name":"legend", "type": "group","children":
+                    [
+                        {"name": "legend names","type":"list","limits":["full","short"]},
+                        {"name":"legend location","type":"list","limits":["best","upper left","upper right","lower left","lower right"]},
+                        {"name":"legend handle length","type":"float","value":0.5,"bounds":(0.1,2)},
+                    ]
+                },
+                {
+                    "name":"Matplotlib styles",
+                    "type":"group",
+                    "children":[
+                        Parameter.create(name=f"{name}",type="bool",value=name in PlotStyleParameters._selected_styles) for name in styles
+                    ]
+                }
+            ]
+        )
+
+
+    def active_styles(self):
+        """Figure out the styles that should be applied to the figure.
+        
+        Multiple styles can be applied, which may override eachother in certain parts.
+        """
+        selected = [child.name() for child in self.child("Matplotlib styles").children() if child.value() is True]
+        PlotStyleParameters._selected_styles = selected
+        return selected
+
+
+class OESMatplotlibExporter(MatplotlibExporter):
+    """A customized exporter for pyqtgraph to matplotlib.
+    
+    It overrides the default (pyqtraph) behaviour slightly to improve the representation.
+    
+    The user can now set multiple Matplotlib stylesheets to apply to the created plot, at runtime.
+
+    Also, the top and right axes are no longer removed, if they are shown in pyqtgraph as well, and enabled by the chosen stylesheets.
+
+    To aid in legend legibility, it is possible to shorten names, reduce the handle length and shorten names, if needed.
+    """
+    Name = "Matplotlib (OESToolbox)"
+
+    def __init__(self,item):
+        super().__init__(item)
+        self.params = PlotStyleParameters()
+
+    @staticmethod
+    def make_legend_name(full_name:str,shorten=False) -> str:
+        """Abbreviate names for use in the legend, if desired."""
+        if not shorten:
+            return full_name.strip()
+        elif "/" in full_name:
+            return full_name.rsplit("/",1)[1].strip()
+        else:
+            return full_name.rsplit(":",1)[1].strip()
+        
+
+    def get_pen_linestyle(self,pen):
+        match pen.style():
+            case Qt.PenStyle.SolidLine:
+                style = "-"
+            case Qt.PenStyle.DotLine:
+                style  = ":"
+            case Qt.PenStyle.DashLine:
+                style  = "--"
+            case Qt.PenStyle.DashDotLine:
+                style = "-."
+            case Qt.PenStyle.PenStyle.DashDotDotLine:
+                style = "dashdotdotted"
+            case Qt.PenStyle.NoPen:
+                style ="none"
+            case _:
+                style="-"
+        return {'ls':style,'color':pen.color().getRgbF(),'linewidth':pen.width()}
+    
+    def get_symbol_style(self,options):
+        """Translate pyqtgraph symbol styles to matplotlib compatible keyword arguments."""
+        symbolPen = pg.mkPen(options['symbolPen'])
+        symbolBrush = pg.mkBrush(options['symbolBrush'])
+        markeredgecolor = symbolPen.color().getRgbF()
+        markerfacecolor = symbolBrush.color().getRgbF()
+        markersize = options['symbolSize']
+        return {
+            "marker":_symbol_pg_to_mpl.get(options["symbol"], ""),
+            "mec":markeredgecolor,
+            "mfc": markerfacecolor,
+            "ms":markersize}
+
+
+    
+    def parameters(self)->PlotStyleParameters:
+        return self.params
+
+    def export(self, fileName=None):
+        if not isinstance(self.item,PlotItem):
+            QMessageBox.information(
+                None,
+                f"{self.item.__class__.__name__} not supported",
+                f"This exporter only support a `PlotItem`, not `{self.item.__class__.__name__}`.\n"
+                "Please select 'Plot' as the target of this export, not 'ViewBox' or 'Entire Scene'."
+            )
+            return
+        mpw = MatplotlibWindow()
+        MatplotlibExporter.windows.append(mpw)
+        abbreviate = self.params.child("legend")['legend names'].lower() == "short"
+        with style.context(self.params.active_styles(), after_reset=True):
+            fig = mpw.getFigure()
+            if self.params['layout engine'].lower()=="constrained":
+                fig.set_constrained_layout(True)
+            dpi=self.params['dpi']
+            if fig.dpi!=dpi:
+                w_px, h_px = fig.canvas.width(), fig.canvas.height()
+                fig.set_size_inches(w_px / dpi, h_px / dpi,forward=True)
+                fig.set_dpi(dpi)
+            xax = self.item.getAxis('bottom')
+            yax = self.item.getAxis('left')
+            ax_right = self.item.getAxis("right")
+            ax_top = self.item.getAxis("top")
+
+            # get labels from the graphic item
+            xlabel = xax.label.toPlainText()
+            ylabel = yax.label.toPlainText()
+            right_label = ax_right.label.toPlainText()
+            top_label = ax_top.label.toPlainText()
+            title = self.item.titleLabel.text
+
+            # if axes use autoSIPrefix, scale the data so mpl doesn't add its own
+            # scale factor label
+            xscale = yscale = right_scale=top_scale= 1.0
+            if xax.autoSIPrefix:
+                xscale = xax.autoSIPrefixScale
+            if yax.autoSIPrefix:
+                yscale = yax.autoSIPrefixScale
+            if ax_right.autoSIPrefix:
+                right_scale = ax_right.autoSIPrefixScale
+            if ax_right.autoSIPrefix:
+                top_scale = ax_top.autoSIPrefixScale
+
+            ax = fig.add_subplot(111, title=title)
+            ax.clear()
+            for item in self.item.curves:
+                if not item.isVisible():
+                    continue
+                x, y = item.getData()
+                item_label = self.make_legend_name(item.name(), abbreviate)
+                x = x * xscale
+                y = y * yscale
+
+                opts = item.opts
+                pen = pg.mkPen(opts['pen'])
+                line_style = self.get_pen_linestyle(pen)
+                marker_style = self.get_symbol_style(opts)
+                
+                if opts['fillLevel'] is not None and opts['fillBrush'] is not None:
+                    fillBrush = pg.mkBrush(opts['fillBrush'])
+                    fillcolor = fillBrush.color().getRgbF()
+                    ax.fill_between(x=x, y1=y, y2=opts['fillLevel'], facecolor=fillcolor)
+                
+                ax.plot(x, y, **line_style,**marker_style, label=item_label, zorder=item.zValue())
+
+                xr, yr = self.item.viewRange()
+                ax.set_xbound(xr[0]*xscale, xr[1]*xscale)
+                ax.set_ybound(yr[0]*yscale, yr[1]*yscale)
+                
+
+            ax.set_xlabel(xlabel)  # place the labels.
+            ax.set_ylabel(ylabel)
+            # Don't force ticks (by line below), but let this be controlled by the selected style(s).
+            # ax.tick_params(axis='both', which='both',direction='in',bottom=True, top=True,left=True,right=True, labelleft=True,labelbottom=True, labelright=False,labeltop=False)
+            if self.item.legend.isVisible() and (len(self.item.legend.items)>0):
+                ax.legend(loc=self.params.child("legend")["legend location"], handlelength=self.params.child("legend")["legend handle length"])
+            if self.params['layout engine'].lower()=="tight":
+                fig.tight_layout()
+            mpw.draw()
+
+class OESDataExporter(Exporter):
+    """An exporter that exports graphed data from the OES-toolbox to a file (text, excel, parquet).
+    
+    This exporter is intended to be used instead of the default pyqtgraph CSVExporter/HDF5Exporter, to be consistent with other methods to export in the OES-toolbox.
+
+    In essence, it triggers the appropriate export action from the main toolbox window, depending on the user selection.
+
+    In case of using a `Plot data` export, the resulting file can be read/plotted again with the OES-toolbox as a set of spectra.
+    """
+    Name = "Export data (OES-toolbox)"
+    
+    def __init__(self,item:PlotItem|GraphicsScene):
+        super().__init__(item)
+        self.params = Parameter.create(name='params', type='group', children=[
+            {"name":"Export data","type":"list","limits":["Plot data","NIST table","Molecule fit results","Continuum results"]},
+        ])
+        self.main_window = item.getViewWidget().window()
+
+
+    def export(self):
+        """Export requested data by calling the appropriate export action on the toolbox main window."""
+        kind = self.params.child("Export data").value()
+        match kind:
+            case "Plot data":
+                self.main_window.action_export_plot_data.trigger()
+            case _s if "NIST" in _s:
+                self.main_window.action_export_ident_table.trigger()
+            case _s if "Molecule" in _s:
+                self.main_window.action_export_molecule_fit_results.trigger()
+            case _s if "Continuum" in _s:
+                self.main_window.action_export_continuum_fit_results.trigger()
+            case _:
+                QMessageBox.warning(self.main_window, "Failed to export file",f"Could perform requested export: {kind}")
+
+    def parameters(self):
+        return self.params
+    
+# Clear the default exports, then register the ones we want to expose in order of priority.
+# SVG/ImageExporter may still be usefull for users.
+pg.exporters.Exporter.Exporters.clear()
+OESMatplotlibExporter.register()
+OESDataExporter.register()
+SVGExporter.register()
+ImageExporter.register()

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -28,6 +28,11 @@ from OES_toolbox._version import version
 pd = lazy_import("pandas")
 
 TOOLBOXSTYLE = "OES_toolbox.ui.jh-paper"
+STYLES = [s for s in style.available if not s.startswith("_")]
+if 'default' not in STYLES:
+    STYLES.insert(0,'default')
+if TOOLBOXSTYLE not in STYLES:
+    STYLES.insert(1,TOOLBOXSTYLE)
 
 class FileExport:
     """Class with methods for exporting data and/or plots to various file types."""
@@ -116,13 +121,8 @@ class FileExport:
     
     @classmethod
     def graph_to_matplotlib(cls, graph) -> Figure:
-        styles = plt.style.available
-        if TOOLBOXSTYLE not in styles:
-            styles.insert(0,TOOLBOXSTYLE)
-        if 'default' not in styles:
-            styles.insert(0,'default')
-        pre_select = 1 if FileExport.pickedLast is None else styles.index(FileExport.pickedLast)
-        picked,ok = QInputDialog.getItem(None,"Pick plot style","Pick the matplotlib stylesheets to apply",styles,pre_select,False)
+        pre_select = 1 if FileExport.pickedLast is None else STYLES.index(FileExport.pickedLast)
+        picked,ok = QInputDialog.getItem(None,"Pick plot style","Pick the matplotlib stylesheets to apply", STYLES, pre_select, False)
         cls.pickedLast = picked
         plt.style.use('default') # Make sure to clear/reset styling to default for predictable results.
         plt.style.use(picked)
@@ -228,12 +228,6 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
     """
     _selected_styles = []
     def __init__(self,**opts):
-        styles = style.available
-        if 'default' not in styles:
-            styles.insert(0,"default")
-        styles = [s for s in styles if not s.startswith("_")]
-        if TOOLBOXSTYLE not in styles:
-            styles.insert(1,TOOLBOXSTYLE)
         super().__init__(name="Export options",**opts)
         self.addChildren(
             [
@@ -250,20 +244,34 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
                     "name":"Matplotlib styles",
                     "type":"group",
                     "children":[
-                        Parameter.create(name=f"{name}",type="bool",value=name in PlotStyleParameters._selected_styles) for name in styles
+                        Parameter.create(name=f"{name}",type="bool",value=name in self._selected_styles) for name in STYLES
                     ]
                 }
             ]
         )
+        for child in self.child("Matplotlib styles").children():
+            child.sigValueChanged.connect(self.toggle_active_style)
 
+    def toggle_active_style(self,sender:Parameter):
+        """Update the list of active styles in order to persist user selection, upon toggle of a specific style."""
+        name:str = sender.name()
+        is_active:bool = sender.value()
+        if is_active and name not in self._selected_styles:
+            self._selected_styles.append(name)
+        elif not is_active and name in self._selected_styles:
+            self._selected_styles.remove(name)
 
     def active_styles(self):
         """Figure out the styles that should be applied to the figure.
         
-        Multiple styles can be applied, which may override eachother in certain parts.
+        Multiple styles can be applied, which may override each other in certain parts, and which depends on ordering.
+
+        This method updates the `_selected_styles` class attribute and always returns styles in the same order as the parameters.
+
+        This ensured a deterministic application of styles, regardless of the order in which they were selected.
         """
         selected = [child.name() for child in self.child("Matplotlib styles").children() if child.value() is True]
-        PlotStyleParameters._selected_styles = selected
+        self._selected_styles = selected
         return selected
 
 
@@ -296,6 +304,7 @@ class OESMatplotlibExporter(MatplotlibExporter):
         
 
     def get_pen_linestyle(self,pen):
+        """Map Qt pen styles to matplotlib compatible keyword arguments."""
         match pen.style():
             case Qt.PenStyle.SolidLine:
                 style = "-"

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -37,11 +37,14 @@ class FileExport:
     @classmethod
     def get_save_path(cls)-> None|Path:
         """Get a file path for saving a file."""
-        filename,_ = QFileDialog.getSaveFileName(caption='Save File', 
-                                                 filter="""Text file (tab-separated)(*.txt);;
-                                                 Text file (comma-separated)(*.csv);;
-                                                 Microsoft Excel (*.xlsx);;Apache Parquet (*.par)
-                                                 """, directory=cls.lastFolder)
+        filename,_ = QFileDialog.getSaveFileName(
+            caption="Save File", 
+            filter="""Text file (tab-separated)(*.txt);;
+            Text file (comma-separated)(*.csv);;
+            Microsoft Excel (*.xlsx);;Apache Parquet (*.par)
+            """, 
+            directory=cls.lastFolder
+        )
         if filename=="":
             return
         filename = Path(filename)
@@ -113,11 +116,21 @@ class FileExport:
     
     @classmethod
     def graph_to_matplotlib(cls, graph) -> Figure:
+        styles = plt.style.available
+        if TOOLBOXSTYLE not in styles:
+            styles.insert(0,TOOLBOXSTYLE)
+        if 'default' not in styles:
+            styles.insert(0,'default')
+        pre_select = 1 if FileExport.pickedLast is None else styles.index(FileExport.pickedLast)
+        picked,ok = QInputDialog.getItem(None,"Pick plot style","Pick the matplotlib stylesheets to apply",styles,pre_select,False)
+        cls.pickedLast = picked
         plt.style.use('default') # Make sure to clear/reset styling to default for predictable results.
-        plt.style.use(TOOLBOXSTYLE)
+        plt.style.use(picked)
         xlim,ylim = graph.getViewBox().viewRange()
         fig = plt.figure(dpi=300)
         for plot_item in graph.listDataItems():
+            if not plot_item.isVisible():
+                continue
             pen = plot_item.opts['pen']            
             style_kws = {
                 "c":pen.color().name(), 

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -124,43 +124,42 @@ class FileExport:
         pre_select = 1 if FileExport.pickedLast is None else STYLES.index(FileExport.pickedLast)
         picked,ok = QInputDialog.getItem(None,"Pick plot style","Pick the matplotlib stylesheets to apply", STYLES, pre_select, False)
         cls.pickedLast = picked
-        plt.style.use('default') # Make sure to clear/reset styling to default for predictable results.
-        plt.style.use(picked)
-        xlim,ylim = graph.getViewBox().viewRange()
-        fig = plt.figure(dpi=300)
-        for plot_item in graph.listDataItems():
-            if not plot_item.isVisible():
-                continue
-            pen = plot_item.opts['pen']            
-            style_kws = {
-                "c":pen.color().name(), 
-                "zorder":plot_item.zValue(),
-                "label": plot_item.name(),
-                "lw": pen.width(),
-            }
-            match pen.style().name.lower():
-                case "solidline":
-                    style_kws['ls'] = "-"
-                case "dotline":
-                    style_kws['ls'] = ":"
-                case 'dashline':
-                    style_kws['ls'] = "--"
-                case "nopen":
-                    style_kws['ls']=''
-            if plot_item.name().startswith("file"):
-                style_kws["label"]=plot_item.name().strip("file:").strip()
-            if plot_item.name().startswith("cont"):
-                style_kws["lw"] = 1
-            elif plot_item.name().startswith('NIST'):
-                style_kws["lw"] = 0.5
-            x,y = plot_item.getData()
-            plt.plot(x,y,**style_kws)
-        plt.xlim(xlim)
-        plt.ylim(ylim)
-        if graph.plotItem.legend.isVisible() and (len(graph.plotItem.legend.items)>0):
-            plt.legend()
-        plt.xlabel(graph.getAxis("bottom").label.toPlainText())
-        plt.ylabel(graph.getAxis("left").label.toPlainText())
+        with plt.style.context(picked,after_reset=True):
+            xlim,ylim = graph.getViewBox().viewRange()
+            fig = plt.figure(dpi=300)
+            for plot_item in graph.listDataItems():
+                if not plot_item.isVisible():
+                    continue
+                pen = plot_item.opts['pen']            
+                style_kws = {
+                    "c":pen.color().name(), 
+                    "zorder":plot_item.zValue(),
+                    "label": plot_item.name(),
+                    "lw": pen.width(),
+                }
+                match pen.style().name.lower():
+                    case "solidline":
+                        style_kws['ls'] = "-"
+                    case "dotline":
+                        style_kws['ls'] = ":"
+                    case 'dashline':
+                        style_kws['ls'] = "--"
+                    case "nopen":
+                        style_kws['ls']=''
+                if plot_item.name().startswith("file"):
+                    style_kws["label"]=plot_item.name().strip("file:").strip()
+                if plot_item.name().startswith("cont"):
+                    style_kws["lw"] = 1
+                elif plot_item.name().startswith('NIST'):
+                    style_kws["lw"] = 0.5
+                x,y = plot_item.getData()
+                plt.plot(x,y,**style_kws)
+            plt.xlim(xlim)
+            plt.ylim(ylim)
+            if graph.plotItem.legend.isVisible() and (len(graph.plotItem.legend.items)>0):
+                plt.legend()
+            plt.xlabel(graph.getAxis("bottom").label.toPlainText())
+            plt.ylabel(graph.getAxis("left").label.toPlainText())
         return fig
     
     @staticmethod

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -187,7 +187,8 @@ class FileExport:
             part_names = [part.strip() for part in plot_item.name().split(": ")]
             match len(part_names):
                 case 2:
-                    part_names.extend([""] * 2)
+                    # Edge case: must set a 'spectrum name' to be able to reliably open the file again using pandas MultiIndex.
+                    part_names.extend(["", "spectrum 0"])
                 case 3:
                     part_names.insert(2, "")
             data.append(pd.DataFrame({(*part_names,label):values for label, values in zip([xlabel,ylabel],[x,y])}))

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -12,7 +12,7 @@ from matplotlib import style
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 
-from PyQt6.QtWidgets import QFileDialog, QMessageBox, QTableWidget, QInputDialog
+from PyQt6.QtWidgets import QFileDialog, QMessageBox, QTableWidget, QInputDialog, QApplication
 from PyQt6.QtGui import QImage, QPixmap
 from PyQt6.QtCore import Qt
 import pyqtgraph as pg
@@ -129,61 +129,6 @@ class FileExport:
             )
     
     @classmethod
-    def graph_to_matplotlib(cls, graph) -> Figure:
-        pre_select = 1 if FileExport.pickedLast is None else STYLES.index(FileExport.pickedLast)
-        picked,ok = QInputDialog.getItem(None,"Pick plot style","Pick the matplotlib stylesheets to apply", STYLES, pre_select, False)
-        cls.pickedLast = picked
-        with plt.style.context(picked,after_reset=True):
-            xlim,ylim = graph.getViewBox().viewRange()
-            fig = plt.figure(dpi=300)
-            for plot_item in graph.listDataItems():
-                if not plot_item.isVisible():
-                    continue
-                pen = plot_item.opts['pen']            
-                style_kws = {
-                    "c":pen.color().name(), 
-                    "zorder":plot_item.zValue(),
-                    "label": plot_item.name(),
-                    "lw": pen.width(),
-                }
-                match pen.style().name.lower():
-                    case "solidline":
-                        style_kws['ls'] = "-"
-                    case "dotline":
-                        style_kws['ls'] = ":"
-                    case 'dashline':
-                        style_kws['ls'] = "--"
-                    case "nopen":
-                        style_kws['ls']=''
-                if plot_item.name().startswith("file"):
-                    style_kws["label"]=plot_item.name().strip("file:").strip()
-                if plot_item.name().startswith("cont"):
-                    style_kws["lw"] = 1
-                elif plot_item.name().startswith('NIST'):
-                    style_kws["lw"] = 0.5
-                x,y = plot_item.getData()
-                plt.plot(x,y,**style_kws)
-            plt.xlim(xlim)
-            plt.ylim(ylim)
-            if graph.plotItem.legend.isVisible() and (len(graph.plotItem.legend.items)>0):
-                plt.legend()
-            plt.xlabel(graph.getAxis("bottom").label.toPlainText())
-            plt.ylabel(graph.getAxis("left").label.toPlainText())
-        return fig
-    
-    @staticmethod
-    def matplotlib_to_image(fig) -> QImage:
-        canvas = FigureCanvas(fig)
-        canvas.draw()
-        img = QImage(
-            canvas.buffer_rgba(), 
-            int(fig.figbbox.width),
-            int(fig.figbbox.height),
-            QImage.Format.Format_RGBA8888_Premultiplied
-        )
-        return img
-    
-    @classmethod
     def save_plot_data(cls, plot,kind:str="plot export", export=True):
         """"Save or export the plotted data.
         
@@ -275,11 +220,11 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
         self.addChildren(
             [
                 {"name":"dpi","value":144,"type":"int","bounds":(30,2400)},
-                {"name":"layout engine","type":"list","limits":["constrained","tight","from style"]},
+                {"name":"layout engine","type":"list","limits":["constrained","tight","from style"],"value":"constrained"},
                 {"name":"legend", "type": "group","children":
                     [
-                        {"name": "legend names","type":"list","limits":["full","short"]},
-                        {"name":"legend location","type":"list","limits":["best","upper left","upper right","lower left","lower right"]},
+                        {"name": "legend names","type":"list","limits":["full","short"],'value':"short"},
+                        {"name":"legend location","type":"list","limits":["best","upper left","upper right","lower left","lower right"],'value':"best"},
                         {"name":"legend handle length","type":"float","value":0.5,"bounds":(0.1,2)},
                     ]
                 },
@@ -331,8 +276,13 @@ class OESMatplotlibExporter(MatplotlibExporter):
     Also, the top and right axes are no longer removed, if they are shown in pyqtgraph as well, and enabled by the chosen stylesheets.
 
     To aid in legend legibility, it is possible to shorten names, reduce the handle length and shorten names, if needed.
+
+    Contrary to the default Matplotlib Exporter, this exporter can export a graph to the system clipboard.
+
+    When doing so, some settings are ignored to create a 'better image' (min dpi: 150)
     """
     Name = "Matplotlib (OESToolbox)"
+    allowCopy = True
 
     def __init__(self,item):
         super().__init__(item)
@@ -384,7 +334,7 @@ class OESMatplotlibExporter(MatplotlibExporter):
     def parameters(self)->PlotStyleParameters:
         return self.params
 
-    def export(self, fileName=None):
+    def export(self, fileName=None,copy=False):
         if not isinstance(self.item,PlotItem):
             QMessageBox.information(
                 None,
@@ -393,14 +343,18 @@ class OESMatplotlibExporter(MatplotlibExporter):
                 "Please select 'Plot' as the target of this export, not 'ViewBox' or 'Entire Scene'."
             )
             return
-        mpw = MatplotlibWindow()
-        MatplotlibExporter.windows.append(mpw)
-        abbreviate = self.params.child("legend")['legend names'].lower() == "short"
+        abbreviate = self.params.child("legend",'legend names').value().lower() == "short"
+
         with style.context(self.params.active_styles(), after_reset=True):
-            fig = mpw.getFigure()
+            if copy is True:
+                fig = plt.figure()
+            else:
+                mpw = MatplotlibWindow()
+                OESMatplotlibExporter.windows.append(mpw)
+                fig = mpw.getFigure()
             if self.params['layout engine'].lower()=="constrained":
                 fig.set_constrained_layout(True)
-            dpi=self.params['dpi']
+            dpi=max(self.params['dpi'],150) if copy else self.params['dpi']
             if fig.dpi!=dpi:
                 w_px, h_px = fig.canvas.width(), fig.canvas.height()
                 fig.set_size_inches(w_px / dpi, h_px / dpi,forward=True)
@@ -464,7 +418,18 @@ class OESMatplotlibExporter(MatplotlibExporter):
                 ax.legend(loc=self.params.child("legend")["legend location"], handlelength=self.params.child("legend")["legend handle length"])
             if self.params['layout engine'].lower()=="tight":
                 fig.tight_layout()
-            mpw.draw()
+            if copy:
+                canvas = FigureCanvas(fig)
+                canvas.draw()
+                img = QImage(
+                    canvas.buffer_rgba(), 
+                    int(fig.figbbox.width),
+                    int(fig.figbbox.height), 
+                    QImage.Format.Format_RGBA8888_Premultiplied
+                )
+                QApplication.clipboard().setImage(img)
+            else:
+                mpw.draw()
 
 class OESDataExporter(Exporter):
     """An exporter that exports graphed data from the OES-toolbox to a file (text, excel, parquet).

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -54,14 +54,15 @@ class FileExport:
 
         When the user cancels the dialog, returns (None,None).
         """
+        supported = (
+                "Text file (tab-separated)(*.txt *.*);;"
+                "Text file (comma-separated)(*.csv *.*);;"
+                "Apache Parquet (*.par)"
+        )
         filename,filter = QFileDialog.getSaveFileName(
             parent=None,
             caption="Save File" if caption is None else caption, 
-            filter=(
-                "Text file (tab-separated)(*.txt *.*);;"
-                "Text file (comma-separated)(*.csv *.*);;"
-                "Microsoft Excel (*.xlsx);;Apache Parquet (*.par)"
-            ), 
+            filter= supported + ";;Microsoft Excel (*.xlsx)" if "export" in caption.lower() else supported, 
             directory=cls.lastFolder
         )
         if filename=="":
@@ -480,13 +481,15 @@ class OESDataExporter(Exporter):
 
         for child in self.params:
             child.sigValueChanged.connect(lambda _:setattr(self.__class__,"_state",self.params.saveState()))
-        self.params.child("Export data").sigValueChanged.connect(lambda x: self.params.child("Save").setValue(x.value()=="Plot data"))
         self.params.child("Export data").sigValueChanged.connect(lambda x: self.params.child("Save").setWritable(x.value()=="Plot data"))
         
 
 
     def export(self):
-        """Export requested data by calling the appropriate export action on the toolbox main window."""
+        """Export requested data by calling the appropriate export action on the toolbox main window.
+        
+        The "Save" parameter only has an effect when dealing with to "Plot data", in other cases it has no meaning.
+        """
         kind = self.params.child("Export data").value()
         is_save = self.params.child("Save").value()
         match kind:

--- a/OES_toolbox/exporters.py
+++ b/OES_toolbox/exporters.py
@@ -219,8 +219,8 @@ class PlotStyleParameters(parameterTypes.GroupParameter):
         super().__init__(name="Export options",**opts)
         self.addChildren(
             [
-                {"name":"dpi","value":144,"type":"int","bounds":(30,2400)},
-                {"name":"layout engine","type":"list","limits":["constrained","tight","from style"],"value":"constrained"},
+                {"name":"dpi","value":300,"type":"int","bounds":(30,2400)},
+                {"name":"layout engine","type":"list","limits":["constrained","tight","from style"],"value":"from style"},
                 {"name":"legend", "type": "group","children":
                     [
                         {"name": "legend names","type":"list","limits":["full","short"],'value':"short"},

--- a/OES_toolbox/file_handling.py
+++ b/OES_toolbox/file_handling.py
@@ -28,6 +28,8 @@ pd = lazy_import("pandas")
 xr = lazy_import("xarray")
 spexread = lazy_import("spexread")
 
+COLUMN_LEVEL_NAMES = ("type","path","region","label","axis") # names of the column MultiIndex of a dataframe saved by OESToolbox
+
 class SpectraDataset:
     """A dataset of spectra recorded with the same wavelength axis and/or region of interest.
 
@@ -249,13 +251,20 @@ class FileLoader:
         if f.suffix.lower()==".par":
             df  = pd.read_parquet(f)
         else:
-            with f.open("r") as fo:
+            with f.open("r",encoding="utf-8") as fo:
                 if "plot export" in fo.readline():
                     kwargs = {"header": [0,1,2,3,4],"index_col":0}
+                    # skip to first few lines until data
+                    for _ in range(1,8):
+                        fo.readline()
+                    sep,dec = cls._infer_text_schema_from_line(fo.readline())
                 else:
                     return 
-            data_fmt = {"sep":"," if f.suffix.lower()==".csv" else "\t","decimal":"."}
+            data_fmt = {"sep":sep,"decimal":dec}
             df = pd.read_csv(f,**data_fmt, encoding='utf-8', comment="#",**kwargs)
+            if not all(left==right for left,right in zip(df.columns.names, COLUMN_LEVEL_NAMES, strict=True)):
+                # fallback for files exported without a MultiIndex for the columns.
+                df = cls._read_generic_text(f)
         return df
 
     @classmethod
@@ -268,13 +277,17 @@ class FileLoader:
         ext = f.suffix.lower()
         if ((b"OES toolbox" in sample) and (b"result" in sample)) or (sample.startswith(b"PAR1")):
             data = cls.read_oestoolbox_export(f)
-            spectra = []
-            for n,g in data.T.groupby(["type","path","region"],sort=False):
-                # Group by unique starting wavelengths to cluster spectra with same axis.
-                for _nn,gg in g.iloc[::2,:].groupby(0, sort=False):
-                    x = gg.iloc[0,:].to_numpy()
-                    y = g.loc[[(*parts[:4],"intensity") for parts in gg.index.drop_duplicates().to_list()]].T.to_numpy()
-                    spectra.append(SpectraDataset(x=x,y=y, name=": ".join(n).strip(": ")))
+            if isinstance(data.columns,pd.MultiIndex):
+                spectra = []
+                for n,g in data.T.groupby(list(COLUMN_LEVEL_NAMES[:3]),sort=False):
+                    # Group by unique starting wavelengths to cluster spectra with same axis.
+                    for _nn,gg in g.iloc[::2,:].groupby(0, sort=False):
+                        x = gg.iloc[0,:].to_numpy()
+                        y = g.loc[[(*parts[:4],"intensity") for parts in gg.index.drop_duplicates().to_list()]].T.to_numpy()
+                        print(f"{n=}")
+                        spectra.append(SpectraDataset(x=x,y=y, name=": ".join(n).strip(": ")))
+            else:
+                spectra = [SpectraDataset(data.iloc[:,i],data.iloc[:,i+1], name=data.columns[i].rsplit(":",1)[0].strip()) for i in range(0,len(data.columns),2)]
         elif b"Data measured with spectrometer [name]:" in sample:
             data = cls.read_avantes_txt(f)
             spectra = [SpectraDataset(x=data.iloc[:, 0],y=data.iloc[:, 1:])]

--- a/OES_toolbox/file_handling.py
+++ b/OES_toolbox/file_handling.py
@@ -251,18 +251,11 @@ class FileLoader:
         else:
             with f.open("r") as fo:
                 if "plot export" in fo.readline():
-                    kwargs = {"header": [2,3,4,5],"index_col":None}
+                    kwargs = {"header": [0,1,2,3,4],"index_col":0}
                 else:
                     return 
-            if f.suffix.lower()==".csv":
-                df = pd.read_csv(f,sep=',', decimal='.', encoding='utf-8', **kwargs)
-            else:
-                df = pd.read_csv(f,sep='\t', decimal='.', encoding='utf-8', **kwargs)
-            cols = df.columns.to_frame()
-            for idx, col in enumerate(cols.columns):     
-                cols.iloc[(0, idx)] = cols.iloc[(0, idx)].lstrip("# ")
-            df.columns = pd.MultiIndex.from_frame(cols)
-            df.columns.set_names(("type","path","label","axis"), inplace=True)
+            data_fmt = {"sep":"," if f.suffix.lower()==".csv" else "\t","decimal":"."}
+            df = pd.read_csv(f,**data_fmt, encoding='utf-8', comment="#",**kwargs)
         return df
 
     @classmethod
@@ -276,12 +269,11 @@ class FileLoader:
         if ((b"OES toolbox" in sample) and (b"result" in sample)) or (sample.startswith(b"PAR1")):
             data = cls.read_oestoolbox_export(f)
             spectra = []
-            num = 4 if f.suffix.lower()==".par" else 3
-            for n,g in data.T.groupby(["type","path"],sort=False):
+            for n,g in data.T.groupby(["type","path","region"],sort=False):
                 # Group by unique starting wavelengths to cluster spectra with same axis.
                 for _nn,gg in g.iloc[::2,:].groupby(0, sort=False):
                     x = gg.iloc[0,:].to_numpy()
-                    y = g.loc[[(*parts[:num],"intensity") for parts in gg.index.drop_duplicates().to_list()]].T.to_numpy()
+                    y = g.loc[[(*parts[:4],"intensity") for parts in gg.index.drop_duplicates().to_list()]].T.to_numpy()
                     spectra.append(SpectraDataset(x=x,y=y, name=": ".join(n).strip(": ")))
         elif b"Data measured with spectrometer [name]:" in sample:
             data = cls.read_avantes_txt(f)

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -124,6 +124,7 @@ class Window(QMainWindow):
         self.actionRefresh_plots.triggered.connect(self.update_spec)
         self.proxy = pg.SignalProxy(self.specplot.scene().sigMouseMoved, rateLimit=90, slot=self.update_plot_pos)
         self.actionClear_Plots.triggered.connect(self.clear_all_spec)
+        self.action_save_data.triggered.connect(lambda: FileExport.save_plot_data(self.specplot,export=False))
     
         # file loading, plotting /drag & drop
         self.button_open.clicked.connect(self.actionOpenFolder.trigger)

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -16,6 +16,7 @@ from PyQt6 import QtCore
 from PyQt6.QtGui import QAction, QImage, QPixmap
 from PyQt6 import sip, QtGui
 import pyqtgraph as pg
+from pyqtgraph.GraphicsScene.exportDialog import ExportDialog
 import webbrowser
 import qtawesome as qta
 
@@ -235,7 +236,11 @@ class Window(QMainWindow):
         self.check_HideLegend.checkStateChanged.connect(
             lambda state: self.specplot.plotItem.legend.setVisible(state == Qt.CheckState.Checked)
         )
-
+        # customize the export dialog to display options better
+        export_dialog = ExportDialog(self.specplot.scene())
+        self.specplot.scene().exportDialog = export_dialog
+        export_dialog.setMinimumSize(300,550)
+        
 
 ##############################################################################
 # <-------------------- basic/general UI function -------------------------> #

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -116,7 +116,6 @@ class Window(QMainWindow):
         top_ax.setHeight(7)
         self.specplot.setAxisItems({"top": top_ax, "right":right_ax})
         self.specplot.addLegend()
-        self.specplot.getViewBox().scene().contextMenu[0].setVisible(False)
 
         self.copy_plots_btn.clicked.connect(self.action_graph_to_clipboard.trigger)
         self.action_graph_to_clipboard.triggered.connect(self.graph_to_clipboard)

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -31,7 +31,7 @@ from OES_toolbox.Widgets import SpectrumTreeItem
 from OES_toolbox.logger import Logger
 from OES_toolbox.lazy_import import lazy_import
 from OES_toolbox.file_handling import FileLoader
-from OES_toolbox.exporters import FileExport
+from OES_toolbox.exporters import FileExport, OESMatplotlibExporter
 
 from importlib.metadata import metadata
 scipy = lazy_import("scipy")
@@ -444,10 +444,8 @@ class Window(QMainWindow):
             
             
     def graph_to_clipboard(self):
-        fig = FileExport.graph_to_matplotlib(self.specplot)
-        img = FileExport.matplotlib_to_image(fig)
-        QApplication.clipboard().setImage(img)
-            
+        exporter=OESMatplotlibExporter(self.specplot.getPlotItem())
+        exporter.export(copy=True)            
 
 ##############################################################################
 # <-------------------- Plotting measurement data -------------------------> #

--- a/OES_toolbox/ui/main.ui
+++ b/OES_toolbox/ui/main.ui
@@ -1248,6 +1248,7 @@
     </widget>
     <addaction name="actionOpenFolder"/>
     <addaction name="actionOpenFiles"/>
+    <addaction name="action_save_data"/>
     <addaction name="menuExport"/>
     <addaction name="actionClearFiles"/>
    </widget>
@@ -1306,6 +1307,14 @@
   <action name="actionOpenFiles">
    <property name="text">
     <string>Open Files</string>
+   </property>
+  </action>
+  <action name="action_save_data">
+   <property name="text">
+    <string>Save data</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
    </property>
   </action>
   <action name="action_export_ident_table">


### PR DESCRIPTION
This PR aims to provide more flexibility and improved quality for export of (mainly) graphs from the toolbox.
As it stands we offer limited export options (only png to clipboard as of 412e346), with no real control over the styling.

While it would be hard to compete with a handcrafted matplotlib figure, *some* level of adjustment over the styling, and support of vector formats are essential for creating plots to share, present, or even publish.

## Overview
In short, this PR: 

* Implements two custom exporters
  *  A custom matplotlib exporter
  * A custom file exporter
*  Re-enables the right-click export menu, reverting 412e346
* Removes unused/unwanted pyqtgraph exporters, in favour of the custom exporters
  * Matplotlib exporter
  * HDF5 exporter
  * CSV exporter
* ~Adds a dialog to 'export graph to clipboard' to prompt the user for a style~

After in-person discussion (see also comments):

* the custom matplotlib exporter can export to clipboard (using its config), no more dialog popups needed. 
* Support two styles when saving plot data to text file: 
  * `Export`: a flat column layout, simpler to read in external programs
  * `Save`:  uses a pandas multi index to preserve hierarchy of files/ROIs better
* storing excel/parquet always uses multi index, so no difference between save/export



## Custom exporters

The file exporter is rather simple: through the export dialog, the user can pick the desired kind of export (spectra, NIST table, Molecule fit table, continuum fit table).
When exporting, the appropriate export action is triggered from the toolbox main window menu, the rest of the process is thus identical.

The matplotlib exporter replaces the default pyqtgraph version.
In the export dialog, it is possible to set a DPI for the file, as well as adjust some legend settings to help in legibility and appearance (shortening names and handles, explicitly setting legend position). 
Further (advanced) customization can be applied through one or more matplotlib stylesheets, which can be selected.
The bundled stylesheet is selected by default at first, but any style that is available systemwide can be used.
This allow e.g. using a seaborn style, or a users custom style(s). 
By applying multiple different stylesheets on top of each other, quite a bit of control over the styling can be achieved. 
Finally, visibility of a plot item (controlled by the pyqtgraph legend) is now also respected, meaning a plotted, but hidden(!) item will no longer be exported.
The result will be a matplotlib window opening, allowing some simple, final adjustments to the plot, which can then be saved to several formats. 

## Export dialog & removed exporters

The CSVExporter, HDF5Exporter and MatplotlibExporter from pyqtgraph are deregistered at runtime, to avoid them being used over the custom ones.
Since they will not show up as options anymore, the right-click menu to export can be shown once more for the graph.

The ImageExporter and SVGExporter are left operational, since they will export the pyqtgraph version of the graph, which may be desired by some. 

## Potential regression

~Exporting to clipboard now asks the user to select a single stylesheet to apply before exporting, meaning it requires one (accept) or two (pick&accept) more actions than before.
An alternative could be to handle this through the custom MatplotlibExporter, picking the currently active choices, without showing a dialog.
The fact that the plot style could be controlled via the right-click menu in that case would be not obvious however, I think.~
No more  dialog needed to adjust styling, the settings of the right-click export dialog are used
