### PR TITLE
Refactor molecule fitting

### DIFF
--- a/OES_toolbox/Widgets.py
+++ b/OES_toolbox/Widgets.py
@@ -460,20 +460,22 @@ class MoleculeCheckBox(QCheckBox):
                 data.wl=data.iloc[:,0]/10 # Angstrom to nm
                 self._db = data
 
-    def get_db(self,wavelength_interval:tuple|None=None):
+    def get_db(self, wavelength_interval:tuple[float,float]|None = None, wl_pad:float|int = 10):
         """Return a slice of a database, or LIFBASE spectrum, within the specified `wavelength_interval`.
 
         If no interval is provided (the default), it will lookup the active bounds from the main window.
 
         If no data(base) has been loaded yet, calling this method will trigger a `load_database` call, which will cache the data.
 
+        To avoid edge effects, it will look up a slightly wider slice of data on both sides of the interval, based on the `wl_pad` argument (default=10).
+
         Note: for automatic lookup of the bounds to work correctly, the widget instance must have a parent that is part of the OESToolbox main window.
         """
         colname = 'wl' if self.src.upper()=="LIFBASE" else 'air_wavelength'
         if wavelength_interval is None:
             wl_min, wl_max, *_= self.window().get_bounds()
-            wavelength_interval = (wl_min,wl_max)
-        
-        data = self.db[self.db[colname].between(*wavelength_interval)]
+        else:
+            wl_min,wl_max = wavelength_interval
+        data = self.db[self.db[colname].between(wl_min - wl_pad, wl_max + wl_pad)]
         return data
      

--- a/OES_toolbox/Widgets.py
+++ b/OES_toolbox/Widgets.py
@@ -6,8 +6,13 @@ from PyQt6.QtCore import Qt
 import pyqtgraph as pg
 import qtawesome as qta
 
+import Moose
+
 from OES_toolbox.file_handling import FileLoader, SpectraDataset
 from OES_toolbox.logger import Logger
+from OES_toolbox.lazy_import import lazy_import
+
+pd = lazy_import("pandas")
 
 from typing import TYPE_CHECKING
 from collections.abc import Callable
@@ -410,3 +415,65 @@ class SpectrumTreeItem(QTreeWidgetItem):
             self.is_content = True # needed to force non-nested files to plot their data, without adding a child node.
             self.set_spectrum(x,y,shift=shift,bg=dataset.background,name=None,bg_is_internal=dataset.has_background)
         self.set_background(None)
+
+class MoleculeCheckBox(QCheckBox):
+    """A checkbox that enables a user to select molecular bands to show or fit.
+    
+    Handles both static spectra from LIFBASE simulation, as well as database files for simulation/fitting.
+
+    Only loads data when needed, caching it to the `_db` attribute.
+
+    A subset of the data (in wavelength range), can be obtained using the `get_db` method.
+    """
+
+    def __init__(self, ident: str, label: str = None, src: str = "LIFBASE", parent=None):
+        super().__init__(parent=parent)
+        self.ident = ident
+        self.label = ident if label is None else label
+        self.src = src
+        self.can_fit = self.src == "mOES"
+        self.setText(self.label)
+        self._db = None
+
+    @property
+    def db(self):
+        if self._db is None:
+            self._load_database()
+        return self._db
+    
+    def _load_database(self):
+        """Load a database or sample LIFBASE simulation and cache it on the instance.
+        
+        The database/file is only loaded if the `_db` attribute is (still) `None`.
+        
+        No filtering/slicing is applied to the database, so it can be cached and re-used effectively.
+        """
+        if self.can_fit and self._db is None:
+            with pg.ProgressDialog(f"Loading line-by-line database: {self.label}",cancelText=None,wait=0,busyCursor=True) as _diag:
+                self._db = Moose.query_DB(self.ident)
+        elif not self.can_fit and self.src=="LIFBASE" and self._db is None:
+            with pg.ProgressDialog(f"Loading LIFBASE simulation: {self.label}",cancelText=None, wait=0) as _diag:
+                # Read the LIFBASE output files, which use lots of whitespace padding and must thus be coerced to float rather than string
+                # FileLoader._read_generic_text fails correctly detecting separator/delimiter because of whitespacing.
+                file_path = f"{Path(__file__).parent}/data/mol_spec/{self.ident}.mod"
+                data = pd.read_csv(file_path,header=None, sep=",",decimal='.',dtype=float,names=["wl","I"])
+                data.wl=data.iloc[:,0]/10 # Angstrom to nm
+                self._db = data
+
+    def get_db(self,wavelength_interval:tuple|None=None):
+        """Return a slice of a database, or LIFBASE spectrum, within the specified `wavelength_interval`.
+
+        If no interval is provided (the default), it will lookup the active bounds from the main window.
+
+        If no data(base) has been loaded yet, calling this method will trigger a `load_database` call, which will cache the data.
+
+        Note: for automatic lookup of the bounds to work correctly, the widget instance must have a parent that is part of the OESToolbox main window.
+        """
+        colname = 'wl' if self.src.upper()=="LIFBASE" else 'air_wavelength'
+        if wavelength_interval is None:
+            wl_min, wl_max, *_= self.window().get_bounds()
+            wavelength_interval = (wl_min,wl_max)
+        
+        data = self.db[self.db[colname].between(*wavelength_interval)]
+        return data
+     

--- a/OES_toolbox/ident.py
+++ b/OES_toolbox/ident.py
@@ -71,18 +71,8 @@ class ident_module:
         self.mw.ident_table.setRowCount(0)
         
         # find wavelength range from file spec
-        for plot_item in self.mw.specplot.listDataItems():
-            if "file" in plot_item.name():
-                x0, x1 = plot_item.dataBounds(0)
-                if lim_unset:
-                    min_x = x0
-                    max_x = x1
-                    max_y = plot_item.dataBounds(1)[1]
-                    lim_unset = False
-                
-                min_x = min(min_x, x0)
-                max_x = max(max_x, x1)
-        
+        min_x, max_x, min_y, max_y = self.mw.get_bounds()
+
         # fetch options
         if self.mw.ident_int_cbox.currentIndex() == 1:
             Te = self.mw.ident_Te.value()

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
     from pandas import DataFrame
     from collections.abc import Callable
 
+import lmfit
+from Moose.lmfit import multi_species_objective
+
+PARAMARGS = ('vary',"min",'max')
+
+DEFAULT_PARAMS = Moose.default_params
+DEFAULT_PARAMS["T_vib"]['max'] = 25000
+DEFAULT_PARAMS["T_rot"]['max'] = 25000
+
 # Exclude high J Swan band database; can quickly run OOM without care
 MOLECULES = [f for f in Moose.database_files if "J300" not in f]
 MOLECULE_DB_LABELS = {
@@ -47,151 +56,119 @@ LIFBASE_LABELS = {
     'CNBX': "CN (B-X)"
 }
 
+# constants for UserRoles for storing fit results with QTableWidgetItems
+PlotItemRole = Qt.ItemDataRole.UserRole+1
+FitResultRole = Qt.ItemDataRole.UserRole+2
 
-def model_for_fit(x, T_rot, T_vib, sim_db, instr, resolution=1000, wl_pad=10):
-    """Function copied from Moose without the normalization to the maximum. """
-    sticks = Moose.create_stick_spectrum(T_vib, T_rot, df_db=sim_db)
-    refined = Moose.equidistant_mesh(sticks, wl_pad=wl_pad, resolution=resolution)
-    simulation = apply_voigt(refined, instr)
-    sim_matched = match_spectra(x.reshape(-1, 1), simulation)
-    return sim_matched[:, 1]
 
-def apply_voigt(sim, instr):
-    """Function copied from Moose to allow arbitrary instrumental functions."""
-    x = sim[:, 0]
-    conv = scipy.signal.fftconvolve(sim[:, 1], instr(x), mode="same")
-    return np.array([x, conv]).T
+def make_fit_params(y, species:list[str], Trot:float, Tvib:float, mu:float, separate_Tvib=True, separate_Trot=True, vary_broadening=True, vary_shift=False) -> lmfit.parameter.Parameters:
+    """Construct suitable fit parameters with bounds for fitting a spectrum with the `Moose.lmfit.multi_species_objective` function.
 
-def match_spectra(meas, sim):
-    """Function copied from Moose to solve out of bounds errors."""
-    interp = scipy.interpolate.make_interp_spline(sim[:, 0], sim[:, 1])
-    interp.extrapolate = False
-    matched_y = interp(meas[:, 0])
-    matched_y = np.nan_to_num(matched_y)
-    return np.array([meas[:, 0], matched_y]).T
+    For each element in the `species` list, it will add `fraction` and optional `T_rot`/`T_vib` parameters, as appropriate.
+    
+    Will calculate bounds and set parameters as free/fixed depending on provided arguments, which can come from the UI state.
 
-def get_mOES_spec(x, Tvib, Trot, data, instr):
-    # TODO: explictily handle errors now that all exceptions are not silently ignored.
-    sim_y = model_for_fit(x, Trot, Tvib, data, instr)
-    return sim_y/np.sum(sim_y)
+    The parameter bounds are made assuming that `multi_species_objective` will be called with the `normalize` kwargs set to `True`.
+
+    This means that `fraction` should be interpreted as a non-normalized `weight` to the total intensity, and is affected by strength of emitter.
+
+    (Stronger emitters will cause a lower weight).
+
+    Arguments:
+        y (NDArray):            The array of y-data, to calculate offset parameter `b` and total amplitude `A` from.
+        species (list[str]):    List of species names, for the species that will be used in the model objective function
+        Trot (float):           Initial estimate of T_rot
+        Tvib (float):           Initial estimate of T_vib
+        mu (float):             Initial wavelength shift in nm.
+        separate_Tvib (bool):   Flag to use different vibrational temperatures for each species
+        separate_Trot (bool):   Flag to use different rotational temperatures for each species
+        vary_broadening (bool): Flag to optimize broadening parameters during fit, or leave them fixed.
+        vary_shift (bool):      Flag to vary the wavelength shift during fitting, or leave it fixed.
+    
+    Returns:
+        Parameters:     A lmfit.Parameters instance with parameter values and bounds configured according to the current UI settings.
+    """
+    #TODO: decide if using `normalize=True` or `False`.
+    separate_Tvib = separate_Tvib and (len(species)>1)
+    separate_Trot = separate_Trot and (len(species)>1)
+    y_min = y.min()
+    y_max = y.max()
+    y_diff = y_max-y_min
+    # var = (y-y_min).std()
+    params = lmfit.create_params(**DEFAULT_PARAMS)
+    params.add("b", y_min, True, y_min - y_diff, y_min + y_diff)
+    params.add("A", y_diff, vary =True, min = 0, max = y_diff*1.5)
+    # params.pop("A")  # use this if using `normalize=False`
+    params['sigma'].vary = vary_broadening
+    params['gamma'].vary = vary_broadening
+    params['mu'].vary = vary_shift
+    params['mu'].value = mu
+    params['T_rot'].value = Trot
+    params['T_vib'].value = Tvib
+    weight = 1/len(species)*y_diff
+    if separate_Tvib:
+        params.pop("T_vib")
+    if separate_Trot:
+        params.pop("T_rot")
+    for specie in species:
+        if separate_Trot:
+            params.add(f"T_rot_{specie}", value = Trot, **{k:v for k,v in DEFAULT_PARAMS['T_vib'].items() if k in PARAMARGS})
+        if separate_Tvib:
+            params.add(f"T_vib_{specie}", value = Tvib, **{k:v for k,v in DEFAULT_PARAMS['T_vib'].items() if k in PARAMARGS})
+        params.add(f"fraction_{specie}", weight,vary=True,min=0,max=1) # adjust if using `normalize=False`
+    return params
 
 
 class MoleculeFitter(QObject):
-    def __init__(self, label, x, y, T_rot,T_vib, molecule_dbs:list["DataFrame"], sep_Trot:bool, sep_Tvib:bool, instr_func, 
-                                            shift=False, stretch=False, parent=None):
+    finished = pyqtSignal()
+    result_ready = pyqtSignal(str, lmfit.minimizer.MinimizerResult, np.ndarray, np.ndarray)
+    progress = pyqtSignal(int)
+
+    
+    def __init__(self, label, x, y, T_rot,T_vib, molecule_dbs:dict[str,"DataFrame"], sep_Trot:bool, sep_Tvib:bool, instr_func, 
+                                            allow_shift=False, allow_stretch=False, parent=None):
         super(self.__class__, self).__init__(parent)
         self.label = label
         self.x, self.y = x,y
         self.T_rot = T_rot # initial value
         self.T_vib = T_vib # initial value
         self.molecule_dbs = molecule_dbs
-        self.sep_Trot, self.sep_Tvib = sep_Trot, sep_Tvib
+        self.sep_Trot = sep_Trot
+        self.sep_Tvib = sep_Tvib
         self.get_instr = instr_func # function copy from Window class
         self.stop = False # stop flag invoked by button press
-        self.shift, self.stretch = shift, stretch
+        self.allow_shift = allow_shift # Plot data is shifted itself, no need for a shift value if using plot data.
+        self.allow_stretch =  allow_stretch
 
-    finished = pyqtSignal()
-    result_ready = pyqtSignal(str, np.ndarray, np.ndarray, np.ndarray)
-    # data_ready = pyqtSignal(str, astropy.table.table.Table)
-    progress = pyqtSignal(int)
-
-
-    def fitfunc(self, x, *args):
-        p0 = list(args) # needed for pop
-        y0 = p0.pop(0)
-        stretch, shift = 0, 0
-        if self.stretch:
-            stretch = p0.pop(-1)
-        if self.shift:
-            shift = p0.pop(-1)
-
-        if not self.sep_Trot:
-            Trot = p0.pop(0)
-        if not self.sep_Tvib:
-            Tvib = p0.pop(0)
-
-        specs = []
-        for db in self.molecule_dbs:
-            A = p0.pop(0)        
-            if self.sep_Trot:
-                Trot = p0.pop(0)
-            if self.sep_Tvib:
-                Tvib = p0.pop(0)
-            x_new = np.mean(x) + ((x - np.mean(x)) * (1 + stretch)) + shift
-            this_spec = A*get_mOES_spec(x_new, Tvib, Trot, db, self.get_instr)
-            specs.append(this_spec)
-        
-        return np.sum(specs, axis=0) + y0
-
-    def construct_fit_args(self):
-        """Create the initial estimates and bounds for `self.fitfunc`, replacing the `molecule_module.fit_spec` method.
-
-        Stopgap solution to avoid dependency on UI state which may change during fitting of many spectra.
-
-        Sadly `fitfunc` does quite a bit of argument mangling and has no consistent signature.
-
-        Rather than rework it, move to lmfit for a more consistent, predictable API.
-        """
-        y_min, y_max, y_std = self.y.min(), self.y.max(), self.y.std()
-        A0 = y_max-y_min
-        p0 = [y_min,]
-        bounds = [[-np.inf],[np.inf]]
-        
-
-        T_bounds = (1,np.inf) # bounds for temperatures
-        if not self.sep_Trot:
-            p0.append(self.T_rot)
-            bounds[0].append(T_bounds[0])
-            bounds[1].append(T_bounds[1])
-        if not self.sep_Tvib:
-            p0.append(self.T_vib)
-            bounds[0].append(T_bounds[0])
-            bounds[1].append(T_bounds[1])
-        # It seems for each species/database the following is appended: `(A0, Optional(T_rot), Optional(T_vib))`
-        # T_rot and T_vib are optional and only included if separately fitted.
-        for _ in range(len(self.molecule_dbs)):
-            p0.append(A0)
-            bounds[0].append(0)
-            bounds[1].append(np.inf)
-            if self.sep_Trot:
-                p0.append(self.T_rot)
-                bounds[0].append(T_bounds[0])
-                bounds[1].append(T_bounds[1])
-            if self.sep_Tvib:
-                p0.append(self.T_vib)
-                bounds[0].append(T_bounds[0])
-                bounds[1].append(T_bounds[1])
-        if self.shift:
-            p0.append(0)
-            bounds[0].append(-10)
-            bounds[1].append(10)
-        if self.stretch:
-            p0.append(0)
-            bounds[0].append(-1)
-            bounds[1].append(1)
-           
-        return p0,bounds
-            
     def fit(self):
         self.progress.emit(1)
-        p0, bounds = self.construct_fit_args()
-
-        try:
-            ans, err = scipy.optimize.curve_fit(
-                self.fitfunc, 
-                self.x, 
-                self.y, 
-                p0=p0, 
-                bounds=bounds
-            )
-            y_fit = self.fitfunc(self.x, *ans)
-
-        except Exception as e:
-            print(e)
-            ans = np.array(p0)
-            y_fit = self.fitfunc(self.x, *ans)
-            
-        self.result_ready.emit(self.label, ans, self.x, y_fit)
+        params=make_fit_params(
+            self.y,
+            species=self.molecule_dbs,
+            Trot = self.T_rot,
+            Tvib=self.T_vib,
+            mu = 0, # Plot data is shifted already
+            vary_shift = self.allow_shift,
+            separate_Tvib=self.sep_Tvib, 
+            separate_Trot=self.sep_Trot,
+            vary_broadening=True
+        )
+        # TODO: investigate if error handling is needed.
+        result = lmfit.minimize(
+            multi_species_objective,
+            params,
+            args=(self.x,),
+            kws=
+            {
+                "y":self.y,
+                "normalize":True,
+                **self.molecule_dbs
+            },
+            ftol=1e-10,
+            max_nfev = 2000
+        )
+        y_fit = multi_species_objective(result.params, x = self.x, normalize = True, **self.molecule_dbs)
+        self.result_ready.emit(self.label, result, self.x, y_fit)
         self.progress.emit(-1)
         self.finished.emit()
 
@@ -238,28 +215,30 @@ class molecule_module:
         
         
         min_x, max_x, min_y ,max_y = self.mw.get_bounds()
+        min_y = max(min_y, 0) # clamp to minimum of 0 for visualization
+
+        Trot = self.mw.mol_Trot_sbox.value()
+        Tvib = self.mw.mol_Tvib_sbox.value()
         
-        # x = np.linspace(min_x)
         for mol_sel in self.molecule_selectors:
             if mol_sel.isChecked(): 
                 db = mol_sel.get_db((min_x, max_x)) # will cache if not loaded yet
-                Trot = self.mw.mol_Trot_sbox.value() if mol_sel.src !="LIFBASE" else 500
-                Tvib = self.mw.mol_Tvib_sbox.value() if mol_sel.src !="LIFBASE" else 2500
-                tag = ' fixed temperature' if mol_sel.src=='LIFBASE' else ''
-                label = f"molecule: {mol_sel.label}{tag} Trot = {Trot:.0f} K Tvib = {Tvib:.0f} K"
                 if db.shape[0]<1:
                     sim_x = [min_x, max_x]
                     sim_y = [0, 0]
                 elif mol_sel.src == "mOES" and mol_sel.can_fit:
                     sim_x = np.linspace(min_x, max_x, int((max_x - min_x) * 200))
-                    sim_y = get_mOES_spec(sim_x, Tvib, Trot, db, self.get_instr)
-                    sim_y = sim_y / np.max(sim_y) * max_y
+                    #TODO: support broadening once more
+                    sim_y = Moose.model_for_fit(sim_x, 0.001, 0.001, 0, Trot, Tvib, A = max_y-min_y, b = min_y, sim_db = db)
                 elif mol_sel.src == "LIFBASE":
                     instr = self.get_instr(db.wl)
                     sim_x = db.wl
                     sim_y = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
-                    sim_y = sim_y/np.max(sim_y) * max_y
-
+                    sim_y = sim_y/np.max(sim_y) * (max_y-min_y)+min_y
+                tag = ' fixed temperature' if mol_sel.src=='LIFBASE' else '' # prefix string with space if not empty
+                tag_Trot = f"Trot = {Trot if mol_sel.src !='LIFBASE' else 500 :.0f} K"
+                tag_Tvib = f"Tvib = {Tvib if mol_sel.src !='LIFBASE' else 2500:.0f} K"
+                label = f"molecule: {mol_sel.label}{tag} {tag_Trot} {tag_Tvib}"
                 self.mw.plot(sim_x, sim_y,label)
 
         self.mw.update_spec_colors()
@@ -289,12 +268,12 @@ class molecule_module:
         separate_Trot = self.mw.mol_multifit_rot_check.isChecked()
         separate_Tvib = self.mw.mol_multifit_vib_check.isChecked()
 
-        dbs = []
+        dbs = {}
         for mol_sel in self.molecule_selectors:
             if mol_sel.isChecked() and mol_sel.can_fit is True:
                 db = mol_sel.get_db()
                 if db.shape[0]>0:
-                    dbs.append(db)
+                    dbs[mol_sel.ident] = db
 
         if self.mw.mol_limit_range_check.isChecked():
             mask = (x>self.mw.mol_min_wl_sbox.value()) & (x<self.mw.mol_max_wl_sbox.value())
@@ -303,17 +282,17 @@ class molecule_module:
 
         mol_fit_thread = QThread()
         fit_worker = MoleculeFitter(
-            label=label, 
-            x=x, 
-            y=y, 
-            T_rot=Trot0,
-            T_vib=Tvib0, 
-            molecule_dbs=dbs,
-            sep_Trot=separate_Trot, 
-            sep_Tvib=separate_Tvib,
-            instr_func=self.get_instr,
-            shift=self.mw.mol_wl_shift_check.isChecked(),
-            stretch=self.mw.mol_wl_stretch_check.isChecked()
+            label = label, 
+            x = x, 
+            y = y, 
+            T_rot = Trot0,
+            T_vib = Tvib0, 
+            molecule_dbs = dbs,
+            sep_Trot = separate_Trot, 
+            sep_Tvib = separate_Tvib,
+            instr_func = self.get_instr,
+            allow_shift = self.mw.mol_wl_shift_check.isChecked(),
+            allow_stretch = self.mw.mol_wl_stretch_check.isChecked()
         )
         
         fit_worker.moveToThread(mol_fit_thread)
@@ -330,72 +309,85 @@ class molecule_module:
         self.mol_fit_workers.append(fit_worker)
 
 
-    def fit_ready(self, label, ans, x_fit, y_fit):
+    def fit_ready(self, label, ans:lmfit.minimizer.MinimizerResult, x_fit, y_fit):
+        def get_species_name(param_name,split_count=2):
+            """Construct a name for a species from a parameter name, if applicable."""
+            parts = param_name.split("_", split_count)
+            return MOLECULE_DB_LABELS.get(parts[split_count],parts[split_count].replace("_"," ")) if len(parts)>split_count else ""
+
         count = self.mw.mol_fit_results_table.rowCount()
         self.mw.mol_fit_results_table.insertRow(count)
+        table = self.mw.mol_fit_results_table
+        current_header = [table.horizontalHeaderItem(i).text() for i in range(table.columnCount())]
 
         self.mw.mol_fit_results_table.setItem(count, 0, QTableWidgetItem(label))
         header = ["file",]
         plot_label = ""
-        col = 1
+        #TODO: figure out using clean labels for the table, while mapping them to parameter names to populate cells
+        print("========================")
+        print("FIT result:")
 
-        if not self.mw.mol_multifit_rot_check.isChecked():
-            col_count = self.mw.mol_fit_results_table.columnCount()
-            if col_count < col + 1:
-                self.mw.mol_fit_results_table.insertColumn(col_count)
-            self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
-            header.append("Trot / K")
-            plot_label += f"Trot={ans[col]:.0f} K"
-            col = col + 1
-
-        if not self.mw.mol_multifit_vib_check.isChecked():
-            col_count = self.mw.mol_fit_results_table.columnCount()
-            if col_count < col + 1:
-                self.mw.mol_fit_results_table.insertColumn(col_count)
-            self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
-            header.append("Tvib / K")
-            plot_label += f" Tvib={ans[col]:.0f} K"
-            col = col + 1
-
-
-        for mol_sel in self.molecule_selectors:
-
-            if mol_sel.isChecked() and mol_sel.can_fit is True:
-                col_count = self.mw.mol_fit_results_table.columnCount()
-                if col_count < col + 1:
-                    self.mw.mol_fit_results_table.insertColumn(col_count)
-                self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
-                header.append("intensity " + mol_sel.label)
-                plot_label += f" {mol_sel.label} "
-                col = col + 1
-
-                if self.mw.mol_multifit_rot_check.isChecked():
-                    col_count = self.mw.mol_fit_results_table.columnCount()
-                    if col_count < col + 1:
-                        self.mw.mol_fit_results_table.insertColumn(col_count)
-                    self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
-                    header.append("Trot " + mol_sel.label)
-                    plot_label += f" Trot={ans[col]:.0f} K"
-                    col = col + 1
-
-                if self.mw.mol_multifit_vib_check.isChecked():
-                    col_count = self.mw.mol_fit_results_table.columnCount()
-                    if col_count < col + 1:
-                        self.mw.mol_fit_results_table.insertColumn(col_count)
-                    self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
-                    header.append("Tvib " + mol_sel.label)
-                    plot_label += f" Tvib={ans[col]:.0f} K"
-                    col = col + 1
+        for p in ans.params:
+            print(f"{p}: {ans.params[p]}")
+            match p:
+                case s if "fraction" in s:
+                    # s = s.replace("_", " ")
+                    species_name = get_species_name(s,1)
+                    # col_name = f"fraction {species_name}"
+                    # if col_name not in current_header:
+                    #     header.append(col_name)
+                    if s not in current_header:
+                        header.append(s)
+                case s if "T_rot" in s:
+                    # s = s.replace("rot_","rot ")+" / K"
+                    species_name = get_species_name(s,2)
+                    # col_name = f"Trot {species_name} / K"
+                    # if col_name not in current_header:
+                    #     header.append(col_name)
+                    if s not in current_header:
+                        header.append(s)                   
+                    plot_label += f"Trot {species_name}={ans.params[p].value:.0f} K "
+                case s if "T_vib" in s:
+                    # s = s.replace("vib_","vib ")+" / K"
+                    species_name = get_species_name(s,2)
+                    # col_name = f"Tvib {species_name} / K"
+                    # if col_name not in current_header:
+                    #     header.append(col_name) 
+                    if s not in current_header:
+                        header.append(s)                   
+                    plot_label += f"Tvib {species_name}={ans.params[p].value:.0f} K "
+                case _:
+                    continue
+        print("========================")
+        print(header,current_header)
+        if header!=current_header:
+            complete_header = current_header+[h for h in header if h not in current_header]
+            table.setColumnCount(len(complete_header))
+            table.setHorizontalHeaderLabels(complete_header)
+        else:
+            complete_header = header
         
-        self.mw.mol_fit_results_table.setColumnCount(col)
-        self.mw.mol_fit_results_table.setHorizontalHeaderLabels(header)
+        row_idx = table.rowCount()-1
+        for p in list(set(ans.params)&set(complete_header)):
+            col_idx = complete_header.index(p)
+            item = QTableWidgetItem()
+            item.setData(Qt.ItemDataRole.DisplayRole,ans.params[p].value)
+            table.setItem(row_idx,col_idx,item)
+
         self.mw.mol_fit_results_table.item(count, 0).y_fit = y_fit
         self.mw.mol_fit_results_table.item(count, 0).x_fit = x_fit
-        self.mw.mol_fit_results_table.item(count, 0).plot_label = plot_label
 
-        for plot_item in self.mw.specplot.listDataItems():
-            if "file" in plot_item.name() and label in plot_item.name():
-                self.mw.plot(x_fit, y_fit, 'molecule: ' + plot_label)
+        # Create the plot item and associate it with the 'file name' cell as UserData, same as fit result, using `PlotItemRole`.
+        # Untill we use a proper MVC pattern, this may be a good start point to show e.g. residual etc.
+        plot_item = pg.PlotDataItem(x=x_fit,y=y_fit, name = f"molecule: {plot_label.strip()}")
+        table.item(row_idx, 0).setData(PlotItemRole,plot_item)
+        table.item(row_idx, 0).plot_item = plot_item
+        table.item(row_idx, 0).setData(FitResultRole,ans)
+        # TODO: consider how to avoid this loop, perhaps we need a reference to the object to be passed along?
+        is_shown = f"file: {label.strip()}" in {item.name() for item in self.mw.specplot.listDataItems()}
+        if is_shown:
+            self.mw.specplot.addItem(plot_item, ignoreBounds=True)
+
                     
         self.mw.update_spec_colors()
 

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -12,6 +12,12 @@ from .Widgets import MoleculeCheckBox
 from .lazy_import import lazy_import
 scipy = lazy_import("scipy")
 Moose = lazy_import("Moose")
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pandas import DataFrame
+    from collections.abc import Callable
+
 # Exclude high J Swan band database; can quickly run OOM without care
 MOLECULES = [f for f in Moose.database_files if "J300" not in f]
 MOLECULE_DB_LABELS = {
@@ -71,13 +77,14 @@ def get_mOES_spec(x, Tvib, Trot, data, instr):
 
 
 class MoleculeFitter(QObject):
-    def __init__(self, label, x, y, p0, molecules, sep_Trot, sep_Tvib, instr_func, 
+    def __init__(self, label, x, y, T_rot,T_vib, molecule_dbs:list["DataFrame"], sep_Trot:bool, sep_Tvib:bool, instr_func, 
                                             shift=False, stretch=False, parent=None):
         super(self.__class__, self).__init__(parent)
         self.label = label
         self.x, self.y = x,y
-        self.p0 = p0
-        self.molecules = molecules
+        self.T_rot = T_rot # initial value
+        self.T_vib = T_vib # initial value
+        self.molecule_dbs = molecule_dbs
         self.sep_Trot, self.sep_Tvib = sep_Trot, sep_Tvib
         self.get_instr = instr_func # function copy from Window class
         self.stop = False # stop flag invoked by button press
@@ -104,48 +111,84 @@ class MoleculeFitter(QObject):
             Tvib = p0.pop(0)
 
         specs = []
-        for mol_sel in self.molecules:
-            if mol_sel.isChecked() and mol_sel.can_fit == True:
-                A = p0.pop(0)        
-                if self.sep_Trot:
-                    Trot = p0.pop(0)
-                if self.sep_Tvib:
-                    Tvib = p0.pop(0)
-                x_new = np.mean(x) + ((x - np.mean(x)) * (1 + stretch)) + shift
-                db = mol_sel.get_db()
-                this_spec = A*get_mOES_spec(x_new, Tvib, Trot, db, self.get_instr)
-                specs.append(this_spec)
+        for db in self.molecule_dbs:
+            A = p0.pop(0)        
+            if self.sep_Trot:
+                Trot = p0.pop(0)
+            if self.sep_Tvib:
+                Tvib = p0.pop(0)
+            x_new = np.mean(x) + ((x - np.mean(x)) * (1 + stretch)) + shift
+            this_spec = A*get_mOES_spec(x_new, Tvib, Trot, db, self.get_instr)
+            specs.append(this_spec)
         
         return np.sum(specs, axis=0) + y0
 
+    def construct_fit_args(self):
+        """Create the initial estimates and bounds for `self.fitfunc`, replacing the `molecule_module.fit_spec` method.
 
+        Stopgap solution to avoid dependency on UI state which may change during fitting of many spectra.
+
+        Sadly `fitfunc` does quite a bit of argument mangling and has no consistent signature.
+
+        Rather than rework it, move to lmfit for a more consistent, predictable API.
+        """
+        y_min, y_max, y_std = self.y.min(), self.y.max(), self.y.std()
+        A0 = y_max-y_min
+        p0 = [y_min,]
+        bounds = [[-np.inf],[np.inf]]
+        
+
+        T_bounds = (1,np.inf) # bounds for temperatures
+        if not self.sep_Trot:
+            p0.append(self.T_rot)
+            bounds[0].append(T_bounds[0])
+            bounds[1].append(T_bounds[1])
+        if not self.sep_Tvib:
+            p0.append(self.T_vib)
+            bounds[0].append(T_bounds[0])
+            bounds[1].append(T_bounds[1])
+        # It seems for each species/database the following is appended: `(A0, Optional(T_rot), Optional(T_vib))`
+        # T_rot and T_vib are optional and only included if separately fitted.
+        for _ in range(len(self.molecule_dbs)):
+            p0.append(A0)
+            bounds[0].append(0)
+            bounds[1].append(np.inf)
+            if self.sep_Trot:
+                p0.append(self.T_rot)
+                bounds[0].append(T_bounds[0])
+                bounds[1].append(T_bounds[1])
+            if self.sep_Tvib:
+                p0.append(self.T_vib)
+                bounds[0].append(T_bounds[0])
+                bounds[1].append(T_bounds[1])
+        if self.shift:
+            p0.append(0)
+            bounds[0].append(-10)
+            bounds[1].append(10)
+        if self.stretch:
+            p0.append(0)
+            bounds[0].append(-1)
+            bounds[1].append(1)
+           
+        return p0,bounds
+            
     def fit(self):
         self.progress.emit(1)
-
-        # A and the temps must be >0
-        self.bounds = [list(np.zeros(len(self.p0))),
-                       list(np.ones(len(self.p0))*np.inf)] 
-        self.bounds[0][0] = -np.inf # y0 -> unbound
-
-        if self.shift:
-            self.p0.append(0.0)
-            self.bounds[0].append(-10) # shift -> +-10
-            self.bounds[1].append(10)
-
-        if self.stretch:
-            self.p0.append(0.0)
-            self.bounds[0].append(-1) # stretch -> +-1
-            self.bounds[1].append(1)
+        p0, bounds = self.construct_fit_args()
 
         try:
-            ans, err = scipy.optimize.curve_fit(self.fitfunc, self.x, self.y, 
-                                    p0=self.p0, bounds=self.bounds)
+            ans, err = scipy.optimize.curve_fit(
+                self.fitfunc, 
+                self.x, 
+                self.y, 
+                p0=p0, 
+                bounds=bounds
+            )
             y_fit = self.fitfunc(self.x, *ans)
 
         except Exception as e:
             print(e)
-            ans = np.array(self.p0)
-            # y_fit = np.zeros(len(self.x))
+            ans = np.array(p0)
             y_fit = self.fitfunc(self.x, *ans)
             
         self.result_ready.emit(self.label, ans, self.x, y_fit)
@@ -243,39 +286,35 @@ class molecule_module:
     def fit_spec(self,x,y,label):    
         Trot0 = self.mw.mol_Trot_sbox.value()
         Tvib0 = self.mw.mol_Tvib_sbox.value()
-        A0 = np.max(y)
-        p0 = [0.0,]
         separate_Trot = self.mw.mol_multifit_rot_check.isChecked()
         separate_Tvib = self.mw.mol_multifit_vib_check.isChecked()
 
-
-        if not separate_Trot:
-            p0.append(Trot0)
-        if not separate_Tvib:
-            p0.append(Tvib0)
-
+        dbs = []
         for mol_sel in self.molecule_selectors:
             if mol_sel.isChecked() and mol_sel.can_fit is True:
-                p0.append(A0)
-                if separate_Trot:
-                    p0.append(Trot0)
-                if separate_Tvib:
-                    p0.append(Tvib0)
+                db = mol_sel.get_db()
+                if db.shape[0]>0:
+                    dbs.append(db)
 
         if self.mw.mol_limit_range_check.isChecked():
             mask = (x>self.mw.mol_min_wl_sbox.value()) & (x<self.mw.mol_max_wl_sbox.value())
             y = y[mask]
             x = x[mask]
-        
-
 
         mol_fit_thread = QThread()
-        fit_worker = MoleculeFitter(label, x, y, p0, self.molecule_selectors, 
-                                    separate_Trot, 
-                                    separate_Tvib,
-                                    self.get_instr,
-                                    self.mw.mol_wl_shift_check.isChecked(),
-                                    self.mw.mol_wl_stretch_check.isChecked())
+        fit_worker = MoleculeFitter(
+            label=label, 
+            x=x, 
+            y=y, 
+            T_rot=Trot0,
+            T_vib=Tvib0, 
+            molecule_dbs=dbs,
+            sep_Trot=separate_Trot, 
+            sep_Tvib=separate_Tvib,
+            instr_func=self.get_instr,
+            shift=self.mw.mol_wl_shift_check.isChecked(),
+            stretch=self.mw.mol_wl_stretch_check.isChecked()
+        )
         
         fit_worker.moveToThread(mol_fit_thread)
         mol_fit_thread.started.connect(fit_worker.fit)

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -182,30 +182,6 @@ class molecule_module:
    
         self.mol_fit_threads = []
         self.mol_fit_workers = []
-        
-
-    def fitfunc(self, x, *args):
-        p0 = list(args) # needed for pop
-        y0 = p0.pop(0)
-
-        if not self.mw.mol_multifit_rot_check.isChecked():
-            Trot = p0.pop(0)
-        if not self.mw.mol_multifit_vib_check.isChecked():
-            Tvib = p0.pop(0)
-
-        specs = []
-        for mol_sel in self.molecule_selectors:
-            if mol_sel.isChecked() and mol_sel.can_fit is True:
-                A = p0.pop(0)        
-                if self.mw.mol_multifit_rot_check.isChecked():
-                    Trot = p0.pop(0)
-                if self.mw.mol_multifit_vib_check.isChecked():
-                    Tvib = p0.pop(0)
-                this_spec = A*get_mOES_spec(x, Tvib, Trot, mol_sel.get_db(), self.get_instr)
-                specs.append(this_spec)
-        
-        return np.sum(specs, axis=0) + y0
-
 
     def show_spec(self):
         self.clear_spec()

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -266,36 +266,34 @@ class molecule_module:
         Tvib0 = self.mw.mol_Tvib_sbox.value()
         A0 = np.max(y)
         p0 = [0.0,]
+        separate_Trot = self.mw.mol_multifit_rot_check.isChecked()
+        separate_Tvib = self.mw.mol_multifit_vib_check.isChecked()
 
-        for mol_sel in self.molecule_selectors:
-            if mol_sel.isChecked() and mol_sel.can_fit == True:
-                mol_sel.load_db((x.min(), x.max())) # `x` is not guaranteed to be sorted/increasing
-                y0 = A0*get_mOES_spec(x, Tvib0, Trot0, mol_sel, self.get_instr)
-                A0 = A0*np.max(y)/np.max(y0)
 
-        if not self.mw.mol_multifit_rot_check.isChecked():
+        if not separate_Trot:
             p0.append(Trot0)
-        if not self.mw.mol_multifit_vib_check.isChecked():
+        if not separate_Tvib:
             p0.append(Tvib0)
 
         for mol_sel in self.molecule_selectors:
-            if mol_sel.isChecked() and mol_sel.can_fit == True:
+            if mol_sel.isChecked() and mol_sel.can_fit is True:
                 p0.append(A0)
-                if self.mw.mol_multifit_rot_check.isChecked():
+                if separate_Trot:
                     p0.append(Trot0)
-                if self.mw.mol_multifit_vib_check.isChecked():
+                if separate_Tvib:
                     p0.append(Tvib0)
 
         if self.mw.mol_limit_range_check.isChecked():
-            y = y[(x>self.mw.mol_min_wl_sbox.value())*(x<self.mw.mol_max_wl_sbox.value())]
-            x = x[(x>self.mw.mol_min_wl_sbox.value())*(x<self.mw.mol_max_wl_sbox.value())]
+            mask = (x>self.mw.mol_min_wl_sbox.value()) & (x<self.mw.mol_max_wl_sbox.value())
+            y = y[mask]
+            x = x[mask]
         
 
 
         mol_fit_thread = QThread()
         fit_worker = MoleculeFitter(label, x, y, p0, self.molecule_selectors, 
-                                    self.mw.mol_multifit_rot_check.isChecked(), 
-                                    self.mw.mol_multifit_vib_check.isChecked(),
+                                    separate_Trot, 
+                                    separate_Tvib,
                                     self.get_instr,
                                     self.mw.mol_wl_shift_check.isChecked(),
                                     self.mw.mol_wl_stretch_check.isChecked())
@@ -395,6 +393,10 @@ class molecule_module:
             for plot_item in self.mw.specplot.listDataItems():
                 if "file" in plot_item.name():
                     x,y = plot_item.getData()
+                    # Remove any element that has either x or y nan
+                    mask = ~np.isnan(x)& ~np.isnan(y)
+                    x = x[mask]
+                    y = y[mask]
                     self.fit_spec(x,y, plot_item.name().replace('file:',''))
                     
         if self.mw.mol_fit_what_combobox.currentIndex() == 1: # fit all checked

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -44,8 +44,6 @@ LIFBASE_LABELS = {
 
 def model_for_fit(x, T_rot, T_vib, sim_db, instr, resolution=1000, wl_pad=10):
     """Function copied from Moose without the normalization to the maximum. """
-    import Moose # free re-implementation of MassiveOES
-
     sticks = Moose.create_stick_spectrum(T_vib, T_rot, df_db=sim_db)
     refined = Moose.equidistant_mesh(sticks, wl_pad=wl_pad, resolution=resolution)
     simulation = apply_voigt(refined, instr)
@@ -56,13 +54,12 @@ def apply_voigt(sim, instr):
     """Function copied from Moose to allow arbitrary instrumental functions."""
     from scipy.signal import fftconvolve
     x = sim[:, 0]
-    conv = fftconvolve(sim[:, 1], instr(x), mode="same")
+    conv = scipy.signal.fftconvolve(sim[:, 1], instr(x), mode="same")
     return np.array([x, conv]).T
 
 def match_spectra(meas, sim):
     """Function copied from Moose to solve out of bounds errors."""
-    from scipy.interpolate import make_interp_spline as interp1d
-    interp = interp1d(sim[:, 0], sim[:, 1])
+    interp = scipy.interpolate.make_interp_spline(sim[:, 0], sim[:, 1])
     interp.extrapolate = False
     matched_y = interp(meas[:, 0])
     matched_y = np.nan_to_num(matched_y)
@@ -143,7 +140,7 @@ class MoleculeFitter(QObject):
             self.bounds[1].append(1)
 
         try:
-            ans, err = curve_fit(self.fitfunc, self.x, self.y, 
+            ans, err = scipy.optimize.curve_fit(self.fitfunc, self.x, self.y, 
                                     p0=self.p0, bounds=self.bounds)
             y_fit = self.fitfunc(self.x, *ans)
 
@@ -213,8 +210,6 @@ class molecule_module:
 
 
     def show_spec(self):
-        from scipy.signal import fftconvolve
-
         self.clear_spec()
             
         min_x = 0
@@ -244,7 +239,7 @@ class molecule_module:
                         
                 if mol_sel.src == "LIFBASE":
                     instr = self.get_instr(db.wl)
-                    simy = fftconvolve(db.I, instr/np.sum(instr), mode='same')
+                    simy = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
                     simy = simy/np.max(simy) * max_y
 
                     self.mw.plot(db.wl, simy, 'molecule: ' + mol_sel.label 

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -44,9 +44,7 @@ LIFBASE_LABELS = {
 
 def model_for_fit(x, T_rot, T_vib, sim_db, instr, resolution=1000, wl_pad=10):
     """Function copied from Moose without the normalization to the maximum. """
-    import Moose # free re-implementation of MassiveOES
-
-    sticks = Moose.create_stick_spectrum(T_vib, T_rot, sim_db)
+    sticks = Moose.create_stick_spectrum(T_vib, T_rot, df_db=sim_db)
     refined = Moose.equidistant_mesh(sticks, wl_pad=wl_pad, resolution=resolution)
     simulation = apply_voigt(refined, instr)
     sim_matched = match_spectra(x.reshape(-1, 1), simulation)
@@ -56,13 +54,12 @@ def apply_voigt(sim, instr):
     """Function copied from Moose to allow arbitrary instrumental functions."""
     from scipy.signal import fftconvolve
     x = sim[:, 0]
-    conv = fftconvolve(sim[:, 1], instr(x), mode="same")
+    conv = scipy.signal.fftconvolve(sim[:, 1], instr(x), mode="same")
     return np.array([x, conv]).T
 
 def match_spectra(meas, sim):
     """Function copied from Moose to solve out of bounds errors."""
-    from scipy.interpolate import make_interp_spline as interp1d
-    interp = interp1d(sim[:, 0], sim[:, 1])
+    interp = scipy.interpolate.make_interp_spline(sim[:, 0], sim[:, 1])
     interp.extrapolate = False
     matched_y = interp(meas[:, 0])
     matched_y = np.nan_to_num(matched_y)
@@ -143,7 +140,7 @@ class MoleculeFitter(QObject):
             self.bounds[1].append(1)
 
         try:
-            ans, err = curve_fit(self.fitfunc, self.x, self.y, 
+            ans, err = scipy.optimize.curve_fit(self.fitfunc, self.x, self.y, 
                                     p0=self.p0, bounds=self.bounds)
             y_fit = self.fitfunc(self.x, *ans)
 
@@ -213,8 +210,6 @@ class molecule_module:
 
 
     def show_spec(self):
-        from scipy.signal import fftconvolve
-
         self.clear_spec()
             
         min_x = 0
@@ -244,7 +239,7 @@ class molecule_module:
                         
                 if mol_sel.src == "LIFBASE":
                     instr = self.get_instr(db.wl)
-                    simy = fftconvolve(db.I, instr/np.sum(instr), mode='same')
+                    simy = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
                     simy = simy/np.max(simy) * max_y
 
                     self.mw.plot(db.wl, simy, 'molecule: ' + mol_sel.label 

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -246,22 +246,8 @@ class molecule_module():
         Te = -1
         lw = -1
         
-        # find wavelength range and max_y from file spec
-        for plot_item in self.mw.specplot.listDataItems():
-            if "file" in plot_item.name():
-                x0, x1 = plot_item.dataBounds(0)
-                if lim_unset:
-                    min_x = x0
-                    max_x = x1
-                    max_y = plot_item.dataBounds(1)[1]
-                    lim_unset = False
-                
-                min_x = min(min_x, x0)
-                max_x = max(max_x, x1)
-
-        if self.mw.mol_limit_range_check.isChecked():
-            min_x = self.mw.mol_min_wl_sbox.value()
-            max_x = self.mw.mol_max_wl_sbox.value()
+        
+        min_x, max_x, min_y ,max_y = self.mw.get_bounds() # TODO: include min_y in bounds for calculations below as well.
         
         # x = np.linspace(min_x)
         for mol_sel in self.molecule_selectors:

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -200,21 +200,24 @@ class molecule_module:
         for mol_sel in self.molecule_selectors:
             if mol_sel.isChecked(): 
                 db = mol_sel.get_db((min_x, max_x)) # will cache if not loaded yet
-                if mol_sel.src == "mOES" and mol_sel.can_fit:
-                    Trot = self.mw.mol_Trot_sbox.value()
-                    Tvib = self.mw.mol_Tvib_sbox.value()
+                Trot = self.mw.mol_Trot_sbox.value() if mol_sel.src !="LIFBASE" else 500
+                Tvib = self.mw.mol_Tvib_sbox.value() if mol_sel.src !="LIFBASE" else 2500
+                tag = ' fixed temperature' if mol_sel.src=='LIFBASE' else ''
+                label = f"molecule: {mol_sel.label}{tag} Trot = {Trot:.0f} K Tvib = {Tvib:.0f} K"
+                if db.shape[0]<1:
+                    sim_x = [min_x, max_x]
+                    sim_y = [0, 0]
+                elif mol_sel.src == "mOES" and mol_sel.can_fit:
                     sim_x = np.linspace(min_x, max_x, int((max_x - min_x) * 200))
                     sim_y = get_mOES_spec(sim_x, Tvib, Trot, db, self.get_instr)
                     sim_y = sim_y / np.max(sim_y) * max_y
-
-                    self.mw.plot(sim_x, sim_y, f"molecule: {mol_sel.label} Trot = {Trot:.0f} K Tvib = {Tvib:.0f} K")
-                        
-                if mol_sel.src == "LIFBASE":
+                elif mol_sel.src == "LIFBASE":
                     instr = self.get_instr(db.wl)
-                    simy = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
-                    simy = simy/np.max(simy) * max_y
+                    sim_x = db.wl
+                    sim_y = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
+                    sim_y = sim_y/np.max(sim_y) * max_y
 
-                    self.mw.plot(db.wl, simy, f"molecule: {mol_sel.label} fixed temperature Trot = 500 K Tvib = 2500 K")
+                self.mw.plot(sim_x, sim_y,label)
 
         self.mw.update_spec_colors()
 

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -52,7 +52,6 @@ def model_for_fit(x, T_rot, T_vib, sim_db, instr, resolution=1000, wl_pad=10):
 
 def apply_voigt(sim, instr):
     """Function copied from Moose to allow arbitrary instrumental functions."""
-    from scipy.signal import fftconvolve
     x = sim[:, 0]
     conv = scipy.signal.fftconvolve(sim[:, 1], instr(x), mode="same")
     return np.array([x, conv]).T
@@ -122,7 +121,6 @@ class MoleculeFitter(QObject):
 
     def fit(self):
         self.progress.emit(1)
-        from scipy.optimize import curve_fit
 
         # A and the temps must be >0
         self.bounds = [list(np.zeros(len(self.p0))),

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import QFileDialog, QTreeWidgetItemIterator, QTableWidgetIt
 from PyQt6.QtCore import Qt, QObject, QThread, pyqtSignal
 from PyQt6.QtGui import QAction
 from PyQt6 import QtGui
+import pyqtgraph as pg
 
 from .Widgets import MoleculeCheckBox
 from .lazy_import import lazy_import

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -435,38 +435,62 @@ class molecule_module:
         self.mw.mol_multitemp_group.setVisible(num_checked>=2)
           
     def clear_table(self):
-        self.mw.mol_fit_results_table.setRowCount(0)
+        """Delete table items row by row to ensure proper cleanup of associated plot items.
+        
+        Must traverse the table in reverse order to avoid index errors as rowCount changes during iteration.
+        """
+        for i in range(self.mw.mol_fit_results_table.rowCount()-1,-1,-1):
+            self.del_table_row(i)
 
     def del_table_row(self, row):
+        """Delete a row from the molecure fit results table and remove the associated plot item."""
+        plot_item = self.mw.mol_fit_results_table.item(row, 0).data(PlotItemRole)
+        self.mw.specplot.removeItem(plot_item)
+        plot_item.deleteLater()
         self.mw.mol_fit_results_table.removeRow(row)
 
+    def del_table_col(self,col):
+        """Delete a column from the fit result table.
+        
+        Will not remove the first column (i.e. the plot item label), since elements in this column contain required extra data in the UserRoles.
+        """
+        if col==0:
+            return
+        self.mw.mol_fit_results_table.removeColumn(col)
+
     def fit_results_rightClick(self, cursor):
+        """Show a right-click menu to interact with the fit result table."""
         row = self.mw.mol_fit_results_table.rowAt(cursor.y())
-        # col = self.mol_fit_results_table.columnAt(cursor.x())
-        plot_label = self.mw.mol_fit_results_table.item(row, 0).plot_label
+        col = self.mw.mol_fit_results_table.columnAt(cursor.x())
+        item = self.mw.mol_fit_results_table.itemAt(cursor)
+        # first column (i.e. the plot label) contains the extra UserRoles (FitResultRole, PlotItemRole)
+        item_col0 = self.mw.mol_fit_results_table.item(row, 0)
+        if item is None:
+            plotted_atm = False
+        else:
+            plot_item = item_col0.data(PlotItemRole)
+            plotted_atm = plot_item in set(self.mw.specplot.listDataItems())
 
         menu = QMenu()
         plot_action = QAction("Plot row", checkable=True)
         del_row_action = QAction("Remove row")
+        del_col_action = QAction("Remove column")
         clear_action = QAction("Clear table")
-        
-        plotted_atm = False
-        for plot_item in self.mw.specplot.listDataItems():
-            if "molecule: " + plot_label in plot_item.name():
-                plotted_atm = True
 
         if plotted_atm:
             plot_action.setChecked(True)
         else:
             plot_action.setChecked(False)
-
-        menu.addAction(plot_action)
-        menu.addAction(del_row_action)
+        if item:
+            menu.addAction(plot_action)
+            plot_action.triggered.connect(lambda: self.plotl_table_item(row, not plotted_atm))
+            menu.addAction(del_row_action)
+            del_row_action.triggered.connect(lambda: self.del_table_row(row))
+        if col !=0:
+            menu.addAction(del_col_action)
         menu.addAction(clear_action)
 
-        plot_action.triggered.connect(lambda: self.plotl_table_item(row, plot_action.isChecked()))
-        del_row_action.triggered.connect(lambda: self.del_table_row(row))
-        del_row_action.triggered.connect(lambda: self.plotl_table_item(row, False))
+        del_col_action.triggered.connect(lambda: self.del_table_col(col))
 
         clear_action.triggered.connect(self.clear_table)
 
@@ -474,18 +498,13 @@ class molecule_module:
 
 
     def plotl_table_item(self, row_idx, plot:bool):
+        """Add or remove a fit result plot to the graph, depending on if it is currently drawn or not."""
+        plot_item = self.mw.mol_fit_results_table.item(row_idx, 0).data(PlotItemRole)
         if plot:
-            y_fit = self.mw.mol_fit_results_table.item(row_idx, 0).y_fit
-            x_fit = self.mw.mol_fit_results_table.item(row_idx, 0).x_fit
-            plot_label = self.mw.mol_fit_results_table.item(row_idx, 0).plot_label
-            self.mw.plot(x_fit, y_fit, 'molecule: ' + plot_label)
-            self.mw.update_spec_colors()
+            self.mw.specplot.addItem(plot_item) 
         else:
-            plot_label = self.mw.mol_fit_results_table.item(row_idx, 0).plot_label
-            for plot_item in self.mw.specplot.listDataItems():
-                if "molecule: " + plot_label in plot_item.name():
-                    self.mw.specplot.removeItem(plot_item)
-            self.mw.update_spec_colors()     
+            self.mw.specplot.removeItem(plot_item)
+        self.mw.update_spec_colors()
 
 
     

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+from pathlib import Path
 import numpy as np
 from PyQt6.QtWidgets import QFileDialog, QTreeWidgetItemIterator, QTableWidgetItem, \
         QMessageBox, QCheckBox, QMenu
@@ -7,7 +8,38 @@ from PyQt6.QtCore import Qt, QObject, QThread, pyqtSignal
 from PyQt6.QtGui import QAction
 from PyQt6 import QtGui
 
-file_dir = os.path.dirname(os.path.abspath(__file__))
+from .Widgets import MoleculeCheckBox
+from .lazy_import import lazy_import
+scipy = lazy_import("scipy")
+Moose = lazy_import("Moose")
+# Exclude high J Swan band database; can quickly run OOM without care
+MOLECULES = [f for f in Moose.database_files if "J300" not in f]
+MOLECULE_DB_LABELS = {
+    "C2_swan":"C₂ Swan",
+    "CNBX": "CN (B-X)",
+    "N2CB": "N₂ (C-B)",
+    "N2PlusBX": "N₂⁺ (B-X)",
+    "NHAX": "NH (A-X)",
+    "NOBX": "NO (B-X)",
+    "OHAX": "OH (A-X)"
+}
+"""Mapping of database names to better looking label for use in UI."""
+
+LIFBASE_SIMS = [f.stem for f in Path(f"{__file__}").parent.joinpath("data/mol_spec").glob("*.mod")]
+LIFBASE_LABELS = {
+    'NOAX': "NO (A-X)",
+    'NOCX': "NO (C-X)",
+    'NODX': "NO (D-X)",
+    'CHAX': "CH (A-X)",
+    'CHBX': "CH (B-X)",
+    'CHCX': "CH (C-X)",
+    'SiHAX': "SiH (A-X)",
+    'CFAX': "CF (A-X)",
+    'CFBX': "CF (B-X)",
+    'CFCX': "CF (C-X)",
+    'CFDX': "CF (D-X)",
+    'CNBX': "CN (B-X)"
+}
 
 
 def model_for_fit(x, T_rot, T_vib, sim_db, instr, resolution=1000, wl_pad=10):
@@ -36,14 +68,9 @@ def match_spectra(meas, sim):
     matched_y = np.nan_to_num(matched_y)
     return np.array([meas[:, 0], matched_y]).T
 
-def get_mOES_spec(x, Tvib, Trot, molecule, instr):
-    try:
-        sim_y = model_for_fit(x, Trot, Tvib, molecule.db, instr)
-    except Exception as e:
-        print(e)
-        print("Warning: Molecular spectrum not in range?")
-        return np.zeros(len(x))
-    
+def get_mOES_spec(x, Tvib, Trot, data, instr):
+    # TODO: explictily handle errors now that all exceptions are not silently ignored.
+    sim_y = model_for_fit(x, Trot, Tvib, data, instr)
     return sim_y/np.sum(sim_y)
 
 
@@ -89,7 +116,8 @@ class MoleculeFitter(QObject):
                 if self.sep_Tvib:
                     Tvib = p0.pop(0)
                 x_new = np.mean(x) + ((x - np.mean(x)) * (1 + stretch)) + shift
-                this_spec = A*get_mOES_spec(x_new, Tvib, Trot, mol_sel, self.get_instr)
+                db = mol_sel.get_db()
+                this_spec = A*get_mOES_spec(x_new, Tvib, Trot, db, self.get_instr)
                 specs.append(this_spec)
         
         return np.sum(specs, axis=0) + y0
@@ -129,84 +157,34 @@ class MoleculeFitter(QObject):
         self.progress.emit(-1)
         self.finished.emit()
 
-    
-
-class molecule_selector(QCheckBox):
-    def __init__(self, molecule):
-        super().__init__()
-        self.label = molecule['label']
-        self.setText(self.label)
-        self.ident = molecule['ident']
-        self.src = molecule['src']
-        self.can_fit = False
-        if self.src == "mOES":
-            self.can_fit = True
-    
-    def load_db(self, wl=(0,99999)):
-        import Moose
-        if self.can_fit:
-            if self.src == "mOES":
-                try:
-                    self.db = Moose.query_DB(self.ident, wl=wl)
-                except:
-                    print("Could not open database for molecular fit.")
-
-
-        # self.addWidget(QLabel("Channel " + str(self.number)))
-        # self.chan_cbox = QComboBox()
 
 
 ##############################################################################
 # <------------------------- molecules module -----------------------------> #
 ##############################################################################   
-class molecule_module():
+class molecule_module:
     def __init__(self, mainWindow):
         self.mw = mainWindow
         self.get_instr = self.mw.settings.get_instr 
-
-        molecule_list = [{'ident': 'C2_swan', 'label': "C₂ Swan", 'src': 'mOES'},
-                         {'ident': 'N2CB', 'label': "N₂ (C-B)", 'src': 'mOES'},
-                         {'ident': 'N2PlusBX', 'label': "N₂⁺ (B-X)", 'src': 'mOES'},
-                         {'ident': 'NHAX', 'label': "NH (A-X)", 'src': 'mOES'},
-                         {'ident': 'NOBX', 'label': "NO (B-X)", 'src': 'mOES'},
-                         {'ident': 'OHAX', 'label': "OH (A-X)", 'src': 'mOES'},
-                         {'ident': 'NOAX', 'label': "NO (A-X)", 'src': 'LIFBASE'},
-                         {'ident': 'NOCX', 'label': "NO (C-X)", 'src': 'LIFBASE'},
-                         {'ident': 'NODX', 'label': "NO (D-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CHAX', 'label': "CH (A-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CHBX', 'label': "CH (B-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CHCX', 'label': "CH (C-X)", 'src': 'LIFBASE'},
-                         {'ident': 'SiHAX', 'label': "SiH (A-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CFAX', 'label': "CF (A-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CFBX', 'label': "CF (B-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CFCX', 'label': "CF (C-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CFDX', 'label': "CF (D-X)", 'src': 'LIFBASE'},
-                         {'ident': 'CNBX', 'label': "CN (B-X)", 'src': 'LIFBASE'},
-                        ]
-            
-        self.molecule_selectors = []
-        col, row = 0, 0   
-        col2, row2 = 0, 0         
+        molecule_list_fit = [{"ident":k,"label":MOLECULE_DB_LABELS.get(k,k), "src":"mOES"} for k in MOLECULES]
+        molecule_list_no_fit = [{'ident':k, "label":LIFBASE_LABELS.get(k,k), "src":"LIFBASE"} for k in LIFBASE_SIMS]
+        
+        self.molecule_selectors:list[MoleculeCheckBox] = []
       
-        for molecule in molecule_list:
-            this_mol_check = molecule_selector(molecule)
-            if this_mol_check.can_fit:
-                this_mol_check.stateChanged.connect(self.change_sel)
-                self.molecule_selectors.append(this_mol_check)
-                self.mw.mol_select_grid.addWidget(this_mol_check, row, col)
-                col = col + 1
-                if col == 3:
-                    row = row + 1
-                    col = 0
-            else:
-                this_mol_check.stateChanged.connect(self.change_sel)
-                self.molecule_selectors.append(this_mol_check)
-                self.mw.mol_select_grid_nofit.addWidget(this_mol_check, row2, col2)
-                col2 = col2 + 1
-                if col2 == 3:
-                    row2 = row2 + 1
-                    col2 = 0
-                
+        for i,molecule in enumerate(molecule_list_fit):
+            row,col = divmod(i,3)
+            this_mol_check = MoleculeCheckBox(**molecule, parent=self.mw)
+            this_mol_check.stateChanged.connect(self.change_sel)
+            self.molecule_selectors.append(this_mol_check)
+            self.mw.mol_select_grid.addWidget(this_mol_check, row, col)
+
+        for i,molecule in enumerate(molecule_list_no_fit):
+            row, col = divmod(i,3)
+            this_mol_check = MoleculeCheckBox(**molecule, parent=self.mw)
+            this_mol_check.stateChanged.connect(self.change_sel)
+            self.molecule_selectors.append(this_mol_check)
+            self.mw.mol_select_grid_nofit.addWidget(this_mol_check, row, col)
+   
         self.mol_fit_threads = []
         self.mol_fit_workers = []
         
@@ -222,13 +200,13 @@ class molecule_module():
 
         specs = []
         for mol_sel in self.molecule_selectors:
-            if mol_sel.isChecked() and mol_sel.can_fit == True:
+            if mol_sel.isChecked() and mol_sel.can_fit is True:
                 A = p0.pop(0)        
                 if self.mw.mol_multifit_rot_check.isChecked():
                     Trot = p0.pop(0)
                 if self.mw.mol_multifit_vib_check.isChecked():
                     Tvib = p0.pop(0)
-                this_spec = A*get_mOES_spec(x, Tvib, Trot, mol_sel, self.get_instr)
+                this_spec = A*get_mOES_spec(x, Tvib, Trot, mol_sel.get_db(), self.get_instr)
                 specs.append(this_spec)
         
         return np.sum(specs, axis=0) + y0
@@ -247,31 +225,29 @@ class molecule_module():
         lw = -1
         
         
-        min_x, max_x, min_y ,max_y = self.mw.get_bounds() # TODO: include min_y in bounds for calculations below as well.
+        min_x, max_x, min_y ,max_y = self.mw.get_bounds()
         
         # x = np.linspace(min_x)
         for mol_sel in self.molecule_selectors:
             if mol_sel.isChecked(): 
-                mol_sel.load_db((min_x, max_x))
+                db = mol_sel.get_db((min_x, max_x)) # will cache if not loaded yet
                 if mol_sel.src == "mOES" and mol_sel.can_fit:
                     Trot = self.mw.mol_Trot_sbox.value()
                     Tvib = self.mw.mol_Tvib_sbox.value()
-                    sim_x = np.linspace(min_x, max_x, 100000)
-                    sim_y = get_mOES_spec(sim_x, Tvib, Trot, mol_sel, self.get_instr)
-                    sim_y = sim_y/np.max(sim_y) * max_y
+                    sim_x = np.linspace(min_x, max_x, int((max_x - min_x) * 200))
+                    sim_y = get_mOES_spec(sim_x, Tvib, Trot, db, self.get_instr)
+                    sim_y = sim_y / np.max(sim_y) * max_y
 
                     self.mw.plot(sim_x, sim_y, 'molecule: ' + mol_sel.label 
                                             + ' Tvib = ' + str(round(Tvib)) 
                                             + ' Trot = ' + str(round(Trot)) )
                         
                 if mol_sel.src == "LIFBASE":
-                    simx,simy = np.loadtxt(file_dir + "/data/mol_spec/" + mol_sel.ident + ".mod", delimiter=",").T
-                    simx = simx/10 # Angstrom to nm
-                    instr = self.get_instr(simx)
-                    simy = fftconvolve(simy, instr/np.sum(instr), mode='same')
+                    instr = self.get_instr(db.wl)
+                    simy = fftconvolve(db.I, instr/np.sum(instr), mode='same')
                     simy = simy/np.max(simy) * max_y
 
-                    self.mw.plot(simx, simy, 'molecule: ' + mol_sel.label 
+                    self.mw.plot(db.wl, simy, 'molecule: ' + mol_sel.label 
                                             + ' fixed temperature Tvib = 2500 K' 
                                             + ' Trot = 500 K' )
 
@@ -449,30 +425,19 @@ class molecule_module():
             if "molecule:" in plot_item.name():
                 self.mw.specplot.removeItem(plot_item)
         self.mw.update_spec_colors()
-                    
-                    # f_sim_y = interp1d(sim_x2, sim_y2, bounds_error=False, fill_value=0)
-                    # sim_y = f_sim_y(x)
                 
     def change_sel(self):
         num_checked = 0
         for mol_sel in self.molecule_selectors:
-            if mol_sel.isChecked(): 
+            if mol_sel.isChecked() and mol_sel.can_fit: 
                 num_checked = num_checked + 1
-        if num_checked >= 2:
-            self.mw.mol_multitemp_group.show()
-        else:
-            self.mw.mol_multitemp_group.hide()
-
-        # self.update_mol()
+        self.mw.mol_multitemp_group.setVisible(num_checked>=2)
           
-    
     def clear_table(self):
         self.mw.mol_fit_results_table.setRowCount(0)
 
-
     def del_table_row(self, row):
         self.mw.mol_fit_results_table.removeRow(row)
-
 
     def fit_results_rightClick(self, cursor):
         row = self.mw.mol_fit_results_table.rowAt(cursor.y())
@@ -507,7 +472,7 @@ class molecule_module():
         menu.exec(QtGui.QCursor.pos())
 
 
-    def plotl_table_item(self, row_idx, plot):
+    def plotl_table_item(self, row_idx, plot:bool):
         if plot:
             y_fit = self.mw.mol_fit_results_table.item(row_idx, 0).y_fit
             x_fit = self.mw.mol_fit_results_table.item(row_idx, 0).x_fit

--- a/OES_toolbox/molecules.py
+++ b/OES_toolbox/molecules.py
@@ -231,18 +231,14 @@ class molecule_module:
                     sim_y = get_mOES_spec(sim_x, Tvib, Trot, db, self.get_instr)
                     sim_y = sim_y / np.max(sim_y) * max_y
 
-                    self.mw.plot(sim_x, sim_y, 'molecule: ' + mol_sel.label 
-                                            + ' Tvib = ' + str(round(Tvib)) 
-                                            + ' Trot = ' + str(round(Trot)) )
+                    self.mw.plot(sim_x, sim_y, f"molecule: {mol_sel.label} Trot = {Trot:.0f} K Tvib = {Tvib:.0f} K")
                         
                 if mol_sel.src == "LIFBASE":
                     instr = self.get_instr(db.wl)
                     simy = scipy.signal.fftconvolve(db.I, instr / np.sum(instr), mode='same')
                     simy = simy/np.max(simy) * max_y
 
-                    self.mw.plot(db.wl, simy, 'molecule: ' + mol_sel.label 
-                                            + ' fixed temperature Tvib = 2500 K' 
-                                            + ' Trot = 500 K' )
+                    self.mw.plot(db.wl, simy, f"molecule: {mol_sel.label} fixed temperature Trot = 500 K Tvib = 2500 K")
 
         self.mw.update_spec_colors()
 
@@ -333,7 +329,7 @@ class molecule_module:
                 self.mw.mol_fit_results_table.insertColumn(col_count)
             self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
             header.append("Trot / K")
-            plot_label = plot_label + " Trot=" + str(round(ans[col],0))
+            plot_label += f"Trot={ans[col]:.0f} K"
             col = col + 1
 
         if not self.mw.mol_multifit_vib_check.isChecked():
@@ -342,19 +338,19 @@ class molecule_module:
                 self.mw.mol_fit_results_table.insertColumn(col_count)
             self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
             header.append("Tvib / K")
-            plot_label = plot_label + " Tvib=" + str(round(ans[col],0))
+            plot_label += f" Tvib={ans[col]:.0f} K"
             col = col + 1
 
 
         for mol_sel in self.molecule_selectors:
 
-            if mol_sel.isChecked() and mol_sel.can_fit == True:
+            if mol_sel.isChecked() and mol_sel.can_fit is True:
                 col_count = self.mw.mol_fit_results_table.columnCount()
                 if col_count < col + 1:
                     self.mw.mol_fit_results_table.insertColumn(col_count)
                 self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
                 header.append("intensity " + mol_sel.label)
-                plot_label = plot_label + " " + mol_sel.label + " "
+                plot_label += f" {mol_sel.label} "
                 col = col + 1
 
                 if self.mw.mol_multifit_rot_check.isChecked():
@@ -363,7 +359,7 @@ class molecule_module:
                         self.mw.mol_fit_results_table.insertColumn(col_count)
                     self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
                     header.append("Trot " + mol_sel.label)
-                    plot_label = plot_label + " Trot=" + str(round(ans[col],0))
+                    plot_label += f" Trot={ans[col]:.0f} K"
                     col = col + 1
 
                 if self.mw.mol_multifit_vib_check.isChecked():
@@ -372,7 +368,7 @@ class molecule_module:
                         self.mw.mol_fit_results_table.insertColumn(col_count)
                     self.mw.mol_fit_results_table.setItem(count, col, QTableWidgetItem(str(round(ans[col],3))))
                     header.append("Tvib " + mol_sel.label)
-                    plot_label = plot_label + " Tvib=" + str(round(ans[col],0))
+                    plot_label += f" Tvib={ans[col]:.0f} K"
                     col = col + 1
         
         self.mw.mol_fit_results_table.setColumnCount(col)
@@ -415,7 +411,7 @@ class molecule_module:
 
     def clear_spec(self):
         for plot_item in self.mw.specplot.listDataItems():
-            if "molecule:" in plot_item.name():
+            if plot_item.name().startswith("molecule:"):
                 self.mw.specplot.removeItem(plot_item)
         self.mw.update_spec_colors()
                 

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -645,7 +645,37 @@ class Window(QMainWindow):
         while iterator.value():
             iterator.value().setCheckState(0,Qt.CheckState.Unchecked)
             iterator += 1
-            
+
+    def get_bounds(self)->tuple[float,float,float,float]:
+        """Get the bounds to apply to the data from the UI state.
+        
+        Finds wavelength and signal ranges from plotted file data ranges.
+
+        If a user specified limit is active, determine the y bounds in this range instead.
+
+        When there is no data plotted from a file, falls back to the user specified limits (even if unchecked).
+
+        TODO: account for padding of the data range by the viewbox, causing ever increasing ranges with repeated actions.
+        """
+        orthoRange=[None,None]
+        min_x = self.mol_min_wl_sbox.value()
+        max_x = self.mol_max_wl_sbox.value()
+        if self.mol_limit_range_check.isChecked():
+            # orthoRange must provided limits of orthogonal axes, thus orthoRange[1] corresponds to x limits to apply when finding y bounds
+            orthoRange[1] = (min_x,max_x)
+
+        vb = self.specplot.getViewBox()
+        target_range = vb.targetRange()
+        file_items = [item for item in vb.addedItems if 'file' in item.name()]
+        
+        if len(file_items)<=0:
+            target_range[0]=[min_x,max_x]
+        bounds =vb.childrenBounds(orthoRange=orthoRange, items=file_items if len(file_items)>0 else None)
+        if bounds[0] is None:
+            bounds[0] = target_range[0]
+        if bounds[1] is None:
+            bounds[1] = target_range[1]
+        return [value for pair in bounds for value in pair]
 
 ##############################################################################
 # <--------------------------- drag & drop --------------------------------> #

--- a/OES_toolbox/toolbox.py
+++ b/OES_toolbox/toolbox.py
@@ -648,7 +648,37 @@ class Window(QMainWindow):
         while iterator.value():
             iterator.value().setCheckState(0,Qt.CheckState.Unchecked)
             iterator += 1
-            
+
+    def get_bounds(self)->tuple[float,float,float,float]:
+        """Get the bounds to apply to the data from the UI state.
+        
+        Finds wavelength and signal ranges from plotted file data ranges.
+
+        If a user specified limit is active, determine the y bounds in this range instead.
+
+        When there is no data plotted from a file, falls back to the user specified limits (even if unchecked).
+
+        TODO: account for padding of the data range by the viewbox, causing ever increasing ranges with repeated actions.
+        """
+        orthoRange=[None,None]
+        min_x = self.mol_min_wl_sbox.value()
+        max_x = self.mol_max_wl_sbox.value()
+        if self.mol_limit_range_check.isChecked():
+            # orthoRange must provided limits of orthogonal axes, thus orthoRange[1] corresponds to x limits to apply when finding y bounds
+            orthoRange[1] = (min_x,max_x)
+
+        vb = self.specplot.getViewBox()
+        target_range = vb.targetRange()
+        file_items = [item for item in vb.addedItems if 'file' in item.name()]
+        
+        if len(file_items)<=0:
+            target_range[0]=[min_x,max_x]
+        bounds =vb.childrenBounds(orthoRange=orthoRange, items=file_items if len(file_items)>0 else None)
+        if bounds[0] is None:
+            bounds[0] = target_range[0]
+        if bounds[1] is None:
+            bounds[1] = target_range[1]
+        return [value for pair in bounds for value in pair]
 
 ##############################################################################
 # <--------------------------- drag & drop --------------------------------> #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "file-read-backwards>=3.0.0",
     "matplotlib>=3.7.0",
-    "moose-spectra>=0.2.1",
+    "moose-spectra>=0.3.0",
     "owlspec>=0.3.0",
     "PyQt6>=6.5.0",
     "pyqtgraph>=0.13.1",
@@ -36,7 +35,8 @@ dependencies = [
     "spexread>=0.2.1",
     "qtawesome>=1.4.0",
     "avaread>=0.2.0",
-    "xlsxwriter>=3.1.0"
+    "xlsxwriter>=3.1.0",
+    "lmfit>=1.3.4"
 ]
 
 [project.scripts]


### PR DESCRIPTION
(This PR is very much WIP; I'll update this post as it progresses, changes will be incremental at first)

## Purpose

This PR seeks to improve how we handle fitting of molecular spectra and how the user can interact with the results.

The goal is to make fitting more robust, but also improve the interaction with it and fix (minor) issues. 

As it stands, there are some small issues involving `NaN` values, or with a 'reversed' wavelength axis (i.e. decreasing), that can cause a fit to fail unexpectedly, without clear reason to the user.

Once fitted, the result table is fairly fragile when changing the amount of species fitted: it won't always put values in the corresponding (correct) column.

Also, apart from showing the fit and summarizing values, there is no other interaction possible to inspect fit parameters and results in detail (e.g. residuals, components of multiple species, etc), which would actually be very useful.

For fitting, it will move to use a model based approach using `lmfit`, to more clearly handle fit parameters and bounds, relying more directly on Moose for the modelling.

Finally, the goal is to decouple UI state from the fitting process. 
Once started, a batch fit can be affected by (and fail due to) changes in the UI, such as (de)selecting a molecule.

## Notable changes

(TODO)
